### PR TITLE
Use GITHUB_REPOSITORY_OWNER for vite.conifg base URL

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,5 @@
 // vite.config.js
 export default {
   // config options
-  base: "https://will-moore.github.io/ome-ngff-validator/"
+  base: `https://${process.env.GITHUB_REPOSITORY_OWNER}.github.io/ome-ngff-validator/`
 };


### PR DESCRIPTION
https://ome.github.io/ome-ngff-validator/ is currently broken since the `vite.config.js` 'base' URL is hard-coded. Trying to fix...