### PR TITLE
Plate validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # ome-ngff-validator
 Web page for validating OME-NGFF files
 
-Currently being deployed at https://ome-ngff-validator.netlify.app/
+Deployed at https://ome.github.io/ome-ngff-validator

--- a/main.js
+++ b/main.js
@@ -9,6 +9,41 @@ const ajv = new Ajv({ strict: false }); // options can be passed, e.g. {allError
 const sample_images_url =
   "https://raw.githubusercontent.com/ome/blog/master/_data/zarr_data_2020-11-04.json";
 
+
+function validateAndLog(schema, jsonData) {
+  console.log(schema);
+  const validate = ajv.compile(schema);
+  const valid = validate(jsonData);
+  if (valid) {
+    log(
+      "<div style='color: green; font-size:24px; border:solid green 1px; padding: 10px; border-radius: 5px; background: #eeffee'>VALID!</span>"
+    );
+  } else {
+    log(
+      "<div style='color: red; font-size:24px; border:solid red 1px; padding: 10px; border-radius: 5px; background: #ffeeee'>NOT VALID!</span>"
+    );
+    validate.errors.forEach((error) => logJson(error));
+  }
+}
+
+async function validatePlate(rootAttrs, source) {
+  const version = rootAttrs.plate.version;
+  if (!version) {
+    log("No 'plate.version' found");
+    return;
+  }
+  log("OME-NGFF plate version: " + version);
+
+    // load Schema - correct version
+    const schema = await getSchema(version, 'plate');
+    log("Validating " + source);
+  
+    // Validate...
+    validateAndLog(schema, rootAttrs);
+}
+
+
+
 async function validateMultiscales(rootAttrs, source) {
   // source is optional - required for loading paths to arrays
 
@@ -21,22 +56,10 @@ async function validateMultiscales(rootAttrs, source) {
 
   // load Schema - correct version
   const schema = await getSchema(version);
-  console.log(schema);
-  const validate = ajv.compile(schema);
+  log("Validating " + source);
 
   // Validate...
-  log("Validating " + source);
-  const valid = validate(rootAttrs);
-  if (valid) {
-    log(
-      "<div style='color: green; font-size:24px; border:solid green 1px; padding: 10px; border-radius: 5px; background: #eeffee'>VALID!</span>"
-    );
-  } else {
-    log(
-      "<div style='color: red; font-size:24px; border:solid red 1px; padding: 10px; border-radius: 5px; background: #ffeeee'>NOT VALID!</span>"
-    );
-    validate.errors.forEach((error) => logJson(error));
-  }
+  validateAndLog(schema, rootAttrs);
 
   // Metadata: axes...
   let axesNames = ["t", "c", "z", "y", "x"];
@@ -72,6 +95,31 @@ async function validateMultiscales(rootAttrs, source) {
   }
 }
 
+async function validateLabels(source) {
+  log("Checking for labels at " + source + "labels/.zattrs");
+  let labelsAttrs;
+  try {
+    labelsAttrs = await getJson(source + "labels/.zattrs");
+    console.log("labelsAttrs", labelsAttrs);
+  } catch (e) {
+    log("No labels found");
+  }
+  if (labelsAttrs) {
+    logJson(labelsAttrs, "labels/.zattrs");
+    if (labelsAttrs.labels) {
+      log("Checking labels: " + JSON.stringify(labelsAttrs.labels));
+      for (let l = 0; l < labelsAttrs.labels.length; l++) {
+        let path = labelsAttrs.labels[l];
+        let labelsPath = source + "labels/" + path + "/";
+        log("Loading..." + labelsPath + ".zattrs");
+        const labelRootAttrs = await getJson(labelsPath + ".zattrs");
+        logJson(labelRootAttrs, "labels/" + path + "/.zattrs");
+        await validateMultiscales(labelRootAttrs, labelsPath);
+      }
+    }
+  }
+}
+
 (async function () {
   // Run this on page load...
   const searchParams = new URLSearchParams(window.location.search);
@@ -90,32 +138,12 @@ async function validateMultiscales(rootAttrs, source) {
   const rootAttrs = await getJson(source + ".zattrs");
   logJson(rootAttrs, ".zattrs JSON");
   if (rootAttrs.multiscales) {
+    // Multiscales validation...
     await validateMultiscales(rootAttrs, source);
-    log("Checking for labels at " + source + "labels/.zattrs");
-    let labelsAttrs;
-    try {
-      labelsAttrs = await getJson(source + "labels/.zattrs");
-      console.log("labelsAttrs", labelsAttrs);
-    } catch (e) {
-      log("No labels found");
-    }
-    if (labelsAttrs) {
-      logJson(labelsAttrs, "labels/.zattrs");
-      if (labelsAttrs.labels) {
-        log("Checking labels: " + JSON.stringify(labelsAttrs.labels));
-        for (let l = 0; l < labelsAttrs.labels.length; l++) {
-          let path = labelsAttrs.labels[l];
-          let labelsPath = source + "labels/" + path + "/";
-          log("Loading..." + labelsPath + ".zattrs");
-          const labelRootAttrs = await getJson(labelsPath + ".zattrs");
-          logJson(labelRootAttrs, "labels/" + path + "/.zattrs");
-          await validateMultiscales(labelRootAttrs, labelsPath);
-        }
-      }
-    }
+    await validateLabels(source);
   } else if (rootAttrs.plate) {
     // validate plate...
-    // TODO...
+    await validatePlate(rootAttrs, source);
   } else {
     log("No multiscales or plate found");
   }

--- a/style.css
+++ b/style.css
@@ -23,3 +23,20 @@ details pre {
   background-color: #2c3e50;
   padding: 10px;
 }
+
+table {
+  margin: 15px auto;
+}
+
+td {
+  border: 1px solid #ddd;
+  width: 20px;
+  height: 20px;
+}
+
+.valid {
+  background-color: #eeffee;
+}
+.invalid {
+  background-color: #ffeeee;
+}

--- a/utils.js
+++ b/utils.js
@@ -37,16 +37,17 @@ export function logJson(data, label) {
 
 let schemas = {};
 
-export async function getSchema(version) {
-  if (!schemas[version]) {
-    const schema_url = `https://raw.githubusercontent.com/ome/ngff/main/${version}/schemas/image.schema`;
+export async function getSchema(version, schemaName="image") {
+  let cacheKey = schemaName + version;
+  if (!schemas[cacheKey]) {
+    const schema_url = `https://raw.githubusercontent.com/ome/ngff/main/${version}/schemas/${schemaName}.schema`;
     log("Loading schema... " + schema_url);
     const schema = await getJson(schema_url);
     // delete to avoid invalid: $schema: "https://json-schema.org/draft/2020-12/schema" not found
     delete schema["$schema"];
-    schemas[version] = schema;
+    schemas[cacheKey] = schema;
   }
-  return schemas[version];
+  return schemas[cacheKey];
 }
 
 function hexToRgb(color) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,8 @@
 // vite.config.js
-export default {
-  // config options
-  base: `https://${process.env.GITHUB_REPOSITORY_OWNER}.github.io/ome-ngff-validator/`
-};
+let config = {};
+// this will be undefined when deployed from netlify, but is used by gh-pages
+if (process.env.GITHUB_REPOSITORY_OWNER) {
+  config.base = `https://${process.env.GITHUB_REPOSITORY_OWNER}.github.io/ome-ngff-validator/`;
+}
+
+export default config;


### PR DESCRIPTION
This adds plate validation:

- Loads Plate Schema from e.g. https://raw.githubusercontent.com/ome/ngff/main/0.4/schemas/plate.schema
- Validates Plate .zattrs
- Iterates through every Well:
    - Uses well.schema to validate each Well (green background on plate)
    - Uses image.schema to validate the FIRST Image of each Well (tick or X)

NB: UI is very basic just now - probably next job is to switch to some UI framework to make this easier.
NB: This only works with a v0.4 plate since we don't have `plate` and `well` schemas available for `0.1`, `0.2`, 0.3`. Can't use the `0.4` schema to validate since it enforces `"version": "0.4"`.
 
To test, deployed at:
https://ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0072B/9512.zarr (v0.4) or e.g. https://ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.1/plates/5966.zarr (v0.1)

![Screenshot 2022-05-27 at 09 50 19](https://user-images.githubusercontent.com/900055/170666359-75da1d49-3d47-4bf1-baf1-06bbaecf3179.png)

