### PR TITLE
Fix deploy on gh pages

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,7 +1,12 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 
-// https://vitejs.dev/config/
-export default defineConfig({
+let config = {
   plugins: [svelte()]
-})
+};
+// this will be undefined when deployed from netlify, but is used by gh-pages
+if (process.env.GITHUB_REPOSITORY_OWNER) {
+  config.base = `https://${process.env.GITHUB_REPOSITORY_OWNER}.github.io/ome-ngff-validator/`;
+}
+
+export default defineConfig(config);


### PR DESCRIPTION
Accidentally broke this in https://github.com/ome/ome-ngff-validator/pull/5/

https://ome.github.io/ome-ngff-validator/ currently not deployed (404 for bundle.js and css)