### PR TITLE
Browse spw

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ome-ngff-validator",
   "private": true,
-  "version": "0.1.1",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ome-ngff-validator",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -1,7 +1,8 @@
 <script>
   import Nav from "./Nav.svelte";
   import JsonValidator from "./JsonValidator.svelte";
-  import Modal from 'svelte-simple-modal';
+  import Title from "./Title.svelte"
+  import Modal from "svelte-simple-modal";
 
   import { getJson } from "./utils";
 
@@ -14,45 +15,43 @@
   let location = window.location.href;
 
   let promise;
-  let zarrName;
 
   if (source) {
     // load JSON to be validated...
     console.log("Loading JSON... " + source + ".zattrs");
     promise = getJson(source + ".zattrs");
-
-    const dirs = source.split("/").filter(Boolean);
-    zarrName = dirs[dirs.length - 1];
   }
 </script>
 
 <Modal>
-<main>
-  <nav>
-    <Nav />
-  </nav>
-  <section>
-    {#if source}
-      <h1>{zarrName}</h1>
-      <div>
+  <main>
+    <nav>
+      <Nav />
+    </nav>
+    <section>
+      {#if source}
         {#await promise}
-          <p>loading...</p>
+          <div>loading...</div>
         {:then data}
-          <JsonValidator rootAttrs={data} {source} />
+          <Title {source} zattrs={data} />
+          <div>
+            <JsonValidator rootAttrs={data} {source} />
+          </div>
         {:catch error}
           <p style="color: red">{error.message}</p>
         {/await}
-      </div>
-    {:else}
-      <article>
-        To validate an OME-ZARR file, use e.g.
-        <a href="{location}?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr">
-          ?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr
-        </a>
-      </article>
-    {/if}
-  </section>
-</main>
+      {:else}
+        <article>
+          To validate an OME-ZARR file, use e.g.
+          <a
+            href="{location}?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr"
+          >
+            ?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr
+          </a>
+        </article>
+      {/if}
+    </section>
+  </main>
 </Modal>
 
 <style>
@@ -67,13 +66,6 @@
     padding: 0;
     flex: 0 0 48px;
     background-color: #343a40;
-  }
-
-  h1 {
-    font-weight: 300;
-    font-size: clamp(2rem, 6vw, 3.5rem);
-    text-align: center;
-    color: #343a40;
   }
 
   section {
@@ -123,6 +115,5 @@
     a {
       white-space: nowrap;
     }
-
   }
 </style>

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,5 +1,10 @@
 
-# 0.1 (July 2022)
+# 0.2.0 (July 2022)
+
+- Support browsing of Plate -> Well -> Image
+- Show and validate Images contained within a Well
+- Show object type in Header. E.g. Image 123.zarr
+# 0.1.0 (July 2022)
 
 - New UI using svelte.js
 - Supports validation of Plate, Well and Image

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,0 +1,7 @@
+
+# 0.1 (July 2022)
+
+- New UI using svelte.js
+- Supports validation of Plate, Well and Image
+- Browsable .zattrs JSON, with links to OME-NGFF spec page
+- Show .zarray details and chunks

--- a/src/ImageContainer.svelte
+++ b/src/ImageContainer.svelte
@@ -1,0 +1,51 @@
+<script>
+  import { getJson, validate } from "./utils";
+
+  export let source;
+  export let path;
+
+  // const promise = getJson(source + path + "/.zattrs");
+
+  async function loadAndValidate() {
+    let imgAttrs = await getJson(source + path + "/.zattrs");
+    console.log("imgAttrs", imgAttrs);
+    let errs = await validate(imgAttrs);
+    return errs;
+  }
+
+  const promise = loadAndValidate();
+</script>
+
+<a title="{path}: Open Image" href="{window.origin}?source={source + path}/">
+{#await promise}
+  <li>{path}.</li>
+{:then errs}
+  {#if errs.length > 0}
+    <li class="error"> ⨯ Error! </li>
+  {:else}
+    <li class="valid">{path}: ✓ </li>
+  {/if}
+{:catch error}
+  <li class="error">{error.message}</li>
+{/await}
+</a>
+
+<style>
+  li {
+    display: block;
+    list-style: none;
+    float: left;
+    border: solid #ddd 1px;
+    margin: 3px;
+    padding: 3px;
+    border-radius: 3px;
+  }
+  .valid {
+    color: green;
+    background-color: #eeffee;
+  }
+  .error {
+    color: red;
+    background-color: #ffeeee;
+  }
+</style>

--- a/src/JsonValidator.svelte
+++ b/src/JsonValidator.svelte
@@ -1,6 +1,7 @@
 <script>
   import MultiscaleArrays from "./MultiscaleArrays.svelte";
   import Plate from "./Plate.svelte";
+  import Well from "./Well.svelte"
   import JsonBrowser from "./JsonBrowser.svelte";
   import {
     CURRENT_VERSION,
@@ -56,6 +57,8 @@
   <MultiscaleArrays {source} {rootAttrs} />
 {:else if rootAttrs.plate}
   <Plate {source} {rootAttrs} />
+{:else if rootAttrs.well}
+  <Well {source} {rootAttrs} />
 {/if}
 
 <style>

--- a/src/Plate.svelte
+++ b/src/Plate.svelte
@@ -22,6 +22,7 @@
   {#await schemasPromise}
     <div>loading schemas...</div>
   {:then ok}
+    <p>Validating {wellPaths.length} Wells and first Image in each:</p>
     <table>
       {#each plateJson.rows as row}
         <tr>

--- a/src/PlateWell.svelte
+++ b/src/PlateWell.svelte
@@ -1,0 +1,52 @@
+<script>
+  import { getJson, validate } from "./utils";
+
+  export let wellAttrs;
+  export let source;
+  export let path;
+
+  async function loadAndValidate() {
+    console.log("wellAttrs", wellAttrs, wellAttrs.well);
+    let imgPath = wellAttrs.well.images[0].path;
+    let imgAttrs = await getJson(source + path + "/" + imgPath + "/.zattrs");
+    let errs = await validate(imgAttrs);
+    return errs;
+  }
+
+  let validatePromise = validate(wellAttrs);
+
+  let imagePromise = loadAndValidate();
+</script>
+
+{#await validatePromise}
+  <td>...</td>
+{:then errors}
+  <td class={errors.length === 0 ? "valid" : "invalid"}>
+    <a title="{path}: Open Well" href="{window.origin}?source={source + path}/">
+      {#await imagePromise}
+        &nbsp
+      {:then imgErrors}
+        {imgErrors.length === 0 ? "✓" : "⨯"}
+      {/await}
+    </a>
+  </td>
+{:catch error}
+  <td style="color: red">{error.message}</td>
+{/await}
+
+<style>
+  td {
+    width: 20px;
+    height: 20px;
+  }
+  td.valid {
+    background-color: #eeffee;
+  }
+  td.invalid {
+    background-color: #ffeeee;
+  }
+  a {
+    text-decoration: none;
+    color: inherit;
+  }
+</style>

--- a/src/Title.svelte
+++ b/src/Title.svelte
@@ -1,0 +1,28 @@
+
+<script>
+
+  export let zattrs;
+  export let source;
+
+  const dirs = source.split("/").filter(Boolean);
+  let title = dirs[dirs.length - 1];
+  let obj = "Image"
+
+  if ("well" in zattrs) {
+    obj = "Well"
+    title = dirs[dirs.length - 2] + "/" + dirs[dirs.length - 1];
+  } else if ("plate" in zattrs) {
+    obj = "Plate"
+  }
+</script>
+
+<h1>{obj}: {title}</h1>
+
+<style>
+  h1 {
+    font-weight: 300;
+    font-size: clamp(2rem, 6vw, 3.5rem);
+    text-align: center;
+    color: #343a40;
+  }
+</style>

--- a/src/WellContainer.svelte
+++ b/src/WellContainer.svelte
@@ -1,7 +1,6 @@
 <script>
   import { getJson } from "./utils";
-  import Well from "./Well.svelte";
-
+  import PlateWell from "./PlateWell.svelte";
   export let source;
   export let path;
 
@@ -11,7 +10,7 @@
 {#await promise}
   <td>.</td>
 {:then data}
-  <Well wellAttrs={data} {source} {path} />
+  <PlateWell wellAttrs={data} {source} {path} />
 {:catch error}
   <td style="color: red">{error.message}</td>
 {/await}


### PR DESCRIPTION
 - When showing a Well, also show the child Images and validate them
 - Each Well (when viewing a Plate) is a link to browse to Well. Each Image (when viewing a Well) is a link to browse to Image
 - Page Header shows object type: E.g. `Image 123.zarr` (instead of just `123.zarr`). For Well, show the last 2 directories for name E.g. `Well: A/1` instead of just `1` previously.
 - Added a CHANGELOG.md with a 0.2.0 entry for this PR. Since we're deploying the master branch, each PR is a release.

To test: e.g. https://deploy-preview-11--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0056B/7361.zarr 