### PR TITLE
Fix links with pathname

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ome-ngff-validator",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/CHANGELOG.md
+++ b/src/CHANGELOG.md
@@ -1,4 +1,7 @@
 
+# 0.2.1 (July 2022)
+
+- Fix links for browsing of Plate -> Well -> Image
 # 0.2.0 (July 2022)
 
 - Support browsing of Plate -> Well -> Image

--- a/src/ImageContainer.svelte
+++ b/src/ImageContainer.svelte
@@ -14,9 +14,11 @@
   }
 
   const promise = loadAndValidate();
+
+  const url = window.location.origin + window.location.pathname;
 </script>
 
-<a title="{path}: Open Image" href="{window.origin}?source={source + path}/">
+<a title="{path}: Open Image" href="{url}?source={source + path}/">
 {#await promise}
   <li>{path}.</li>
 {:then errs}

--- a/src/PlateWell.svelte
+++ b/src/PlateWell.svelte
@@ -16,13 +16,15 @@
   let validatePromise = validate(wellAttrs);
 
   let imagePromise = loadAndValidate();
+
+  const url = window.location.origin + window.location.pathname;
 </script>
 
 {#await validatePromise}
   <td>...</td>
 {:then errors}
   <td class={errors.length === 0 ? "valid" : "invalid"}>
-    <a title="{path}: Open Well" href="{window.origin}?source={source + path}/">
+    <a title="{path}: Open Well" href="{url}?source={source + path}/">
       {#await imagePromise}
         &nbsp
       {:then imgErrors}


### PR DESCRIPTION
Bug-fix: Clicking on Wells e.g. https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0001A/2551.zarr/ gives a 404 since the URL doesn't include the `window.location.pathname`. This isn't needed when deployed on a dev-server (during development) or on netlify (PR preview) but on github pages, it IS.
The `window.location.pathname` is `/ome-ngff-validator/` (e.g. enter `window.location.pathname` into the dev console at the above URL) and this is missing from the URLs to Wells.

So, this PR should fix the deployment above, but can't really be tested on the PR preview (although it will still work since `window.location.pathname` is `/` on the netlify deploy). 

NB: Updated Changelog with this as 0.2.1