### PR TITLE
Multi well validation

### DIFF
--- a/index.html
+++ b/index.html
@@ -169,13 +169,13 @@
       textarea:focus {
         outline-width: 0;
       }
-      select {
+      /* select {
         -moz-appearance: none;
         -webkit-appearance: none;
       }
       select::-ms-expand {
         display: none;
-      }
+      } */
       select::-ms-value {
         color: currentColor;
       }

--- a/src/JsonValidator/Plate/WellContainer/PlateWell.svelte
+++ b/src/JsonValidator/Plate/WellContainer/PlateWell.svelte
@@ -1,15 +1,37 @@
 <script>
-  import { getJson, validate } from "../../../utils";
+  import { getJson, validate, getSearchParam, range } from "../../../utils";
 
   export let wellAttrs;
   export let source;
   export let path;
 
+  const wellToValidate = getSearchParam("well");
+  let wellIndex = parseInt(wellToValidate);
+  let wellIndices = [0];
+  if (isNaN(wellIndex)) {
+    if (wellToValidate == "all") {
+      wellIndices = range(wellAttrs.well.images.length);
+    }
+  } else {
+    wellIndices = [wellIndex];
+  }
+
+  let loadingIndex = 0;
+
   async function loadAndValidate() {
     console.log("wellAttrs", wellAttrs, wellAttrs.well);
-    let imgPath = wellAttrs.well.images[0].path;
-    let imgAttrs = await getJson(source + path + "/" + imgPath + "/.zattrs");
-    let errs = await validate(imgAttrs);
+    let errs = [];
+    const imgs = wellAttrs.well.images;
+    for (let i=0; i < wellIndices.length; i++) {
+      // this will fail if e.g. any getJson() raises exception
+      let index = wellIndices[i];
+      if (index >= imgs.length) {
+        return ["Invalid Well index: " + index];
+      }
+      loadingIndex = index;
+      let imgAttrs = await getJson(source + path + "/" + imgs[index].path + "/.zattrs");
+      errs = errs.concat(await validate(imgAttrs));
+    };
     return errs;
   }
 
@@ -26,9 +48,17 @@
   <td class={errors.length === 0 ? "valid" : "invalid"}>
     <a title="{path}: Open Well" href="{url}?source={source + path}/">
       {#await imagePromise}
-        &nbsp
+        {#if wellToValidate == "all"}
+          <span title="Loading Well index: {loadingIndex}" style="color:rgba(0,0,0,0.2)">{loadingIndex}</span>
+        {/if}
       {:then imgErrors}
-        {imgErrors.length === 0 ? "✓" : "⨯"}
+        {#if imgErrors.length === 0}
+          ✓
+        {:else}
+          <span title={imgErrors.join(", ")} style="color:red">⨯</span>
+        {/if}
+      {:catch error}
+        <span style="color:red">⨯</span>
       {/await}
     </a>
   </td>

--- a/src/JsonValidator/Plate/WellContainer/PlateWell.svelte
+++ b/src/JsonValidator/Plate/WellContainer/PlateWell.svelte
@@ -19,7 +19,6 @@
   let loadingIndex = 0;
 
   async function loadAndValidate() {
-    console.log("wellAttrs", wellAttrs, wellAttrs.well);
     let errs = [];
     const imgs = wellAttrs.well.images;
     for (let i=0; i < wellIndices.length; i++) {
@@ -55,10 +54,10 @@
         {#if imgErrors.length === 0}
           ✓
         {:else}
-          <span title={imgErrors.join(", ")} style="color:red">⨯</span>
+          <span title={imgErrors.join(", ")} style="color:red">X</span>
         {/if}
       {:catch error}
-        <span style="color:red">⨯</span>
+        <span style="color:red">X</span>
       {/await}
     </a>
   </td>

--- a/src/JsonValidator/Plate/index.svelte
+++ b/src/JsonValidator/Plate/index.svelte
@@ -1,10 +1,24 @@
 <script>
-  import { CURRENT_VERSION, getVersion, getSchema } from "../../utils";
+  import { CURRENT_VERSION, getVersion, getSchema, getSearchParam } from "../../utils";
 
   import WellContainer from "./WellContainer/index.svelte";
 
   export let source;
   export let rootAttrs;
+
+  const wellToValidate = getSearchParam("well");
+  let testParse = parseInt(wellToValidate);
+  let wellIndex = 0;
+  if (!isNaN(testParse)) {
+    wellIndex = testParse;
+  }
+
+  const searchParams = new URLSearchParams(window.location.search);
+  function wellUrl(wellIndex) {
+    searchParams.set("well", "" + wellIndex);
+    return window.location.origin + window.location.pathname + "?" + searchParams;
+  }
+
 
   let plateJson = rootAttrs.plate;
   let wellPaths = plateJson.wells.map((well) => well.path);
@@ -22,7 +36,20 @@
   {#await schemasPromise}
     <div>loading schemas...</div>
   {:then ok}
-    <p>Validating {wellPaths.length} Wells and first Image in each:</p>
+    <p>
+      Validating {wellPaths.length} Wells and
+      {#if wellToValidate == "all"}
+        ALL Images in each
+        <a href={wellUrl(0)} title="Validate Image at index {wellIndex}">index:0 only</a>
+      {:else}
+        one Image in each (index: {wellIndex})
+        <a href={wellUrl('all')} title="Validate ALL Images in each Well">all</a>
+        {#if wellIndex > 0}
+          <a href={wellUrl(wellIndex - 1)} title="Validate Image at index {wellIndex - 1}"> &lt; </a>
+        {/if}
+        <a href={wellUrl(wellIndex + 1)} title="Validate Image at index {wellIndex + 1}"> &gt; </a>
+      {/if}
+    </p>
     <table>
       {#each plateJson.rows as row}
         <tr>
@@ -51,5 +78,9 @@
     background-color: #eee;
     width: 20px;
     height: 20px;
+  }
+
+  a {
+    text-decoration: none;
   }
 </style>

--- a/src/utils.js
+++ b/src/utils.js
@@ -135,3 +135,13 @@ export function formatBytes(bytes) {
   var i = Math.floor(Math.log(bytes) / Math.log(1000));
   return (bytes / Math.pow(1000, i)).toFixed(2) + " " + sizes[i];
 }
+
+export function getSearchParam(key) {
+  const searchParams = new URLSearchParams(window.location.search);
+  let value = searchParams.get(key);
+  return value;
+}
+
+export function range(length) {
+  return Array.from({ length }, (_, i) => i);
+}


### PR DESCRIPTION
Currently, when validating a Plate, we only validate the First image in each Well and there's no way to validate other Images except to open each Well in turn.

This PR allows you to choose a Well Index to validate and also allows you to validate ALL Wells in a Plate.
However, this can result in loading a lot of data, so it's not the default behaviour.

To test, use e.g. plate `SQ00014814__2016-05-23T17_24_56-Measurement1.ome.zarr/` PR deployment:

https://deploy-preview-14--ome-ngff-validator.netlify.app/?source=https://cellpainting-gallery.s3.amazonaws.com/cpg0004-lincs/broad/images/2016_04_01_a549_48hr_batch1/images_zarr/SQ00014814__2016-05-23T17_24_56-Measurement1.ome.zarr/

Use the `all` link to check all Wells (or add `&well=all` to the URL). This highlights 1 Well that is invalid:

![Screenshot 2022-10-17 at 16 12 34](https://user-images.githubusercontent.com/900055/196216690-56b64059-5f0d-41ca-a365-cc24c0e692a3.png)

Clicking on that Well shows which Images are invalid:

![Screenshot 2022-10-17 at 16 13 40](https://user-images.githubusercontent.com/900055/196215694-5e18a032-e00f-4873-ba18-946aac8adc24.png)
