### PR TITLE
Fix rendering of list with false-like first item

### DIFF
--- a/src/JsonBrowser/index.svelte
+++ b/src/JsonBrowser/index.svelte
@@ -32,19 +32,19 @@
     {/if}
 
     <!-- opening bracket for list or object -->
-    {#if contents[0]}{"["}{:else}{"{"}{/if}
+    {#if Array.isArray(contents)}{"["}{:else}{"{"}{/if}
 
     <!-- if NOT expanded, show ...] // n items -->
     {#if !expanded}
-      <span class="comment dots">...</span> {#if contents[0]}{"]"}{:else}{"}"}{/if}
+      <span class="comment dots">...</span> {#if Array.isArray(contents)}{"]"}{:else}{"}"}{/if}
       {#if (!last) }<span class="trailing-comma">,</span>{/if}
-      <span class="comment">// {#if contents[0]}{contents.length}{:else}{Object.keys(contents).length}{/if} items</span>
+      <span class="comment">// {#if Array.isArray(contents)}{contents.length}{:else}{Object.keys(contents).length}{/if} items</span>
     {/if}
 
     {#if expanded}
       <ul transition:slide={{ duration: 300 }}>
         <!-- If it's a list show each item or contents -->
-        {#if contents[0]}
+        {#if Array.isArray(contents)}
           {#each contents as item, count}
             <li>
               {#if typeof item === "object"}
@@ -59,11 +59,11 @@
               {:else}
                 <!-- Value, string or number or null, boolean -->
                 {#if typeof item === "string"}
-                  <span class="string">"{item}"</span>
+                  <span class="string indent">"{item}"</span>
                 {:else if typeof item === "number"}
-                  <span class="number">{item}</span>
+                  <span class="number indent">{item}</span>
                 {:else}
-                  <span class="null">{item}</span>
+                  <span class="null indent">{item}</span>
                 {/if}
                 {#if contents.length != (count + 1)}
                   <span class="trailing-comma">,</span>
@@ -108,7 +108,7 @@
 
     {#if expanded}
       <!-- closing bracket for list or object -->
-      {#if contents[0]}{"]"} {:else} {"}"} {/if}
+      {#if Array.isArray(contents)}{"]"} {:else} {"}"} {/if}
       {#if !last}<span class="trailing-comma">,</span>{/if}
     {/if}
   </div>


### PR DESCRIPTION
Previously I was incorrectly using `if contents[0]` to check if `contents` was a list. This returns `False` if the first item in the list is False.

See https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr
where the `translation` list is rendered instead as a dict.

![Screenshot 2022-10-20 at 14 34 04](https://user-images.githubusercontent.com/900055/196964013-6fa4f703-ddf7-49cb-9053-6984685737a2.png)

Fixed by using `Array.isArray()`: deployed at https://deploy-preview-15--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457539.zarr

![Screenshot 2022-10-20 at 14 33 37](https://user-images.githubusercontent.com/900055/196964116-838af012-18c1-44e4-8f9a-2d0cc4360be4.png)

Also tweaked the indent of list items.