### PR TITLE
Fix versions for dtype checks. Don't check v0.4

### DIFF
--- a/src/JsonValidator/MultiscaleArrays/Multiscale.svelte
+++ b/src/JsonValidator/MultiscaleArrays/Multiscale.svelte
@@ -11,8 +11,7 @@
   // If multiscale.axes (version > 0.3) check it matches shape
   const {axes, datasets, version} = multiscale;
 
-  // TODO: add "0.4" to this list once tested!
-  const checkDtypes = !["0.1", "0.2", "0.3"].includes(version);
+  const checkDtypes = !["0.1", "0.2", "0.3", "0.4"].includes(version);
   const checkDimSeparator = ["0.2", "0.3", "0.4"].includes(version);
 
   function allEqual(items) {


### PR DESCRIPTION
My bad: For https://github.com/ome/ome-ngff-validator/pull/16#issuecomment-1297636546 the validator checks dtypes for v0.4 NGFF and asserts failure if dtypes mismatch (so that the PR could be tested).
However, v0.4 NGFF with mismatching dtypes are not actually invalid.
I forgot to revert that change before merging. So this PR fixes that and ONLY asserts that mismatching dtypes are invalid for versions *after* v0.4, to correspond to https://github.com/ome/ngff/pull/154

So, checking the mismatching dytpe sample from the PR above (v0.4) should no-longer give a warning:
https://deploy-preview-18--ome-ngff-validator.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z.zarr
