### PR TITLE
Load zarr chunks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "ome-ngff-validator",
-  "version": "0.0.0",
+  "version": "0.3.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ome-ngff-validator",
-      "version": "0.0.0",
+      "version": "0.3.0",
       "dependencies": {
         "ajv": "^8.11.0",
         "svelte-icons-pack": "^1.4.6",
-        "svelte-simple-modal": "^1.4.1"
+        "svelte-simple-modal": "^1.4.1",
+        "zarr": "^0.6.0"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^1.0.0-next.30",
@@ -460,6 +461,11 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -551,6 +557,40 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "dependencies": {
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-parse": {
@@ -752,6 +792,18 @@
         "stylus": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zarr": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.6.0.tgz",
+      "integrity": "sha512-WgGe+aFyK6EmTyZcqJ2OFeFQ9fJFuJqeJgM5sKnbap7HJboaI+rBpDp0rPXSTq5ITu/rLEQjZQ2mPlcfYk7DYA==",
+      "dependencies": {
+        "numcodecs": "^0.2.2",
+        "p-queue": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     }
   },
@@ -980,6 +1032,11 @@
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -1047,6 +1104,25 @@
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
       "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
       "dev": true
+    },
+    "numcodecs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/numcodecs/-/numcodecs-0.2.2.tgz",
+      "integrity": "sha512-Y5K8mv80yb4MgVpcElBkUeMZqeE4TrovxRit/dTZvoRl6YkB6WEjY+fiUjGCblITnt3T3fmrDg8yRWu0gOLjhQ=="
+    },
+    "p-queue": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
+      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
+      "requires": {
+        "eventemitter3": "^4.0.7",
+        "p-timeout": "^5.0.2"
+      }
+    },
+    "p-timeout": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
+      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
     },
     "path-parse": {
       "version": "1.0.7",
@@ -1167,6 +1243,15 @@
         "postcss": "^8.4.13",
         "resolve": "^1.22.0",
         "rollup": "^2.59.0"
+      }
+    },
+    "zarr": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/zarr/-/zarr-0.6.0.tgz",
+      "integrity": "sha512-WgGe+aFyK6EmTyZcqJ2OFeFQ9fJFuJqeJgM5sKnbap7HJboaI+rBpDp0rPXSTq5ITu/rLEQjZQ2mPlcfYk7DYA==",
+      "requires": {
+        "numcodecs": "^0.2.2",
+        "p-queue": "^7.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "svelte-icons-pack": "^1.4.6",
-    "svelte-simple-modal": "^1.4.1"
+    "svelte-simple-modal": "^1.4.1",
+    "zarr": "^0.6.0"
   }
 }

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkLoader.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkLoader.svelte
@@ -1,0 +1,51 @@
+<script>
+    import { range } from "../../../utils";
+    import { get, writable } from 'svelte/store';
+
+    export let source;
+    export let path;
+    export let zarray;
+  
+
+    const ch = zarray.chunks;
+    const chunkCounts = zarray.shape.map((sh, index) => Math.ceil(sh / ch[index]));
+
+    console.log('chunkCounts', chunkCounts);
+
+    // let chunkIndices = chunkCounts.map(c => 0);
+
+    const chunkStore = writable(chunkCounts.map(c => 0));
+  
+    function handleLoadChunks() {
+      console.log("handle chunks", get(chunkStore));
+    }
+
+    chunkStore.subscribe(function(chunkIndices){
+      console.log("subscribe chunkIndices", chunkIndices)
+    })
+  </script>
+  
+      <div class="chunkLoader">
+        Load chunk:
+        <input type="checkbox" on:change={handleLoadChunks}/>
+        {#each chunkCounts as cc, dim}
+          <select name="dim_{dim}" bind:value={$chunkStore[dim]}>
+            {#each range(cc) as opt}
+              <option value={opt}>{opt}</option>
+            {/each}
+          </select>
+        {/each}
+      </div>
+  
+  <style>
+  
+    .chunkLoader {
+      width: max-content;
+      margin: 10px auto;
+      background: white;
+      border-radius: 10px;
+      padding: 10px;
+    }
+
+  </style>
+  

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
@@ -2,6 +2,8 @@
   import { onMount, afterUpdate } from "svelte";
 
   export let chunk;
+  // e.g. chunkSlice is [0,1,0,0]
+  export let chunkSlice;
 
   let canvas;
   let ctx;
@@ -13,31 +15,46 @@
   const height = shape[shape.length - 2];
 
   function getMinMaxValues(rawChunk) {
-      // rawChunk.data is single array
-      let maxV = 0;
-      let minV = Infinity;
-      let d = rawChunk.data;
-      let size = d.length;
-      console.log('d', d);
-      for (let i = 0; i < size; i++) {
-        let v = d[i];
-          maxV = Math.max(maxV, v);
-          minV = Math.min(minV, v);
-      }
-      return [minV, maxV];
+    // rawChunk.data is single array
+    let maxV = 0;
+    let minV = Infinity;
+    let d = rawChunk.data;
+    let size = d.length;
+    console.log("d", d);
+    for (let i = 0; i < size; i++) {
+      let v = d[i];
+      maxV = Math.max(maxV, v);
+      minV = Math.min(minV, v);
+    }
+    return [minV, maxV];
   }
 
-  export function renderTo8bitArray(rawChunks) {
+  export function renderTo8bitArray(rawChunks, chunkSlice) {
+    // Render a raw chunk into a 2D 8-bit data for new ImageData(arr)
     // rawChunks is list of zarr arrays
+    // chunkSlice (optional) e.g. if chunk.shape is (1,125,125,125)
+    // we can use slice of [0,50,0,0] to view 50th z section
 
     let minMaxValues = rawChunks.map(getMinMaxValues);
 
-    console.log('minMaxValues', minMaxValues);
+    let sliceOffset = 0;
+    // assume all chunks are same shape
+    const shape = rawChunks[0].shape;
+    const height = shape[0];
+    const width = shape[1];
+
+    if (chunkSlice) {
+      // ignore last 2 dimensions, offset by a plane * index
+      sliceOffset = chunkSlice
+        .slice(0, -2)
+        .reduce((prev, sliceIndex, dimIndex) => {
+          // FIXME: this works for 3D, but won't work for 4D
+          return prev + sliceIndex * width * height;
+        }, 0);
+    }
 
     let rgb = [255, 255, 255];
 
-    const height = rawChunks[0].shape[0];
-    const width = rawChunks[0].shape[1];
     const rgba = new Uint8ClampedArray(4 * height * width).fill(0);
     let offset = 0;
     for (let y = 0; y < height; y++) {
@@ -45,17 +62,17 @@
         for (let p = 0; p < rawChunks.length; p++) {
           let data = rawChunks[p].data;
           let range = minMaxValues[p];
-          let rawValue = data[offset];
+          let rawValue = data[sliceOffset + offset];
           let fraction = (rawValue - range[0]) / (range[1] - range[0]);
           // for red, green, blue,
           for (let i = 0; i < 3; i++) {
             // lut[i] is 0-255...
             let v = (fraction * rgb[i]) << 0;
             // increase pixel intensity if value is higher
-            rgba[(offset * 4) + i] = Math.max(rgba[(offset * 4) + i], v);
+            rgba[offset * 4 + i] = Math.max(rgba[offset * 4 + i], v);
           }
         }
-        rgba[(offset * 4) + 3] = 255; // alpha
+        rgba[offset * 4 + 3] = 255; // alpha
         offset += 1;
       }
     }
@@ -65,7 +82,7 @@
   onMount(() => {
     ctx = canvas.getContext("2d");
 
-    let rgb = renderTo8bitArray([chunk]);
+    let rgb = renderTo8bitArray([chunk], chunkSlice);
     console.log("rgb data", rgb);
 
     ctx.putImageData(new ImageData(rgb, width, height), 0, 0);
@@ -73,7 +90,7 @@
 
   afterUpdate(() => {
     console.log("Updated....");
-    let rgb = renderTo8bitArray([chunk]);
+    let rgb = renderTo8bitArray([chunk], chunkSlice);
     console.log("rgb data....", rgb);
 
     ctx.putImageData(new ImageData(rgb, width, height), 0, 0);

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
@@ -1,56 +1,56 @@
 <script>
   import { onMount, afterUpdate } from "svelte";
+  import { slice } from "zarr";
 
   export let chunk;
-  // e.g. chunkSlice is [0,1,0,0]
+  // e.g. chunkSlice is [1,0,0]...
   export let chunkSlice;
 
+  let errorMsg;
+  let minMaxMsg;
   let canvas;
   let ctx;
 
-  let shape = chunk.shape;
-  console.log("chunkViewer shape", chunk.shape);
 
-  const width = shape[shape.length - 1];
-  const height = shape[shape.length - 2];
+  const width = chunk.shape[chunk.shape.length - 1];
+  const height = chunk.shape[chunk.shape.length - 2];
 
-  function getMinMaxValues(rawChunk) {
-    // rawChunk.data is single array
+  function getMinMaxValues(chunk2d) {
+    const shape = chunk2d.shape;
+    const height = shape[0];
+    const width = shape[1];
+    const data = chunk2d.data;
     let maxV = 0;
     let minV = Infinity;
-    let d = rawChunk.data;
-    let size = d.length;
-    console.log("d", d);
-    for (let i = 0; i < size; i++) {
-      let v = d[i];
-      maxV = Math.max(maxV, v);
-      minV = Math.min(minV, v);
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        let rawValue = data[y][x];
+        maxV = Math.max(maxV, rawValue);
+        minV = Math.min(minV, rawValue);
+      }
     }
     return [minV, maxV];
   }
 
-  export function renderTo8bitArray(rawChunks, chunkSlice) {
-    // Render a raw chunk into a 2D 8-bit data for new ImageData(arr)
-    // rawChunks is list of zarr arrays
-    // chunkSlice (optional) e.g. if chunk.shape is (1,125,125,125)
-    // we can use slice of [0,50,0,0] to view 50th z section
+  function sliceArray(ndChunk, toSlice) {
+    let slice2D = [...toSlice];
+    // don't slice last 2 dims - so we get 2D array
+    slice2D[slice2D.length - 1] = slice(null);
+    slice2D[slice2D.length - 2] = slice(null);
+    return ndChunk.get(slice2D);
+  }
 
-    let minMaxValues = rawChunks.map(getMinMaxValues);
+  export function renderTo8bitArray(ndChunks, minMaxValues) {
+    // Render chunks (array) into 2D 8-bit data for new ImageData(arr)
+    // ndChunks is list of zarr arrays
 
-    let sliceOffset = 0;
     // assume all chunks are same shape
-    const shape = rawChunks[0].shape;
+    const shape = ndChunks[0].shape;
     const height = shape[0];
     const width = shape[1];
 
-    if (chunkSlice) {
-      // ignore last 2 dimensions, offset by a plane * index
-      sliceOffset = chunkSlice
-        .slice(0, -2)
-        .reduce((prev, sliceIndex, dimIndex) => {
-          // FIXME: this works for 3D, but won't work for 4D
-          return prev + sliceIndex * width * height;
-        }, 0);
+    if (!minMaxValues) {
+      minMaxValues = ndChunks.map(getMinMaxValues);
     }
 
     let rgb = [255, 255, 255];
@@ -59,10 +59,10 @@
     let offset = 0;
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
-        for (let p = 0; p < rawChunks.length; p++) {
-          let data = rawChunks[p].data;
+        for (let p = 0; p < ndChunks.length; p++) {
+          let data = ndChunks[p].data;
           let range = minMaxValues[p];
-          let rawValue = data[sliceOffset + offset];
+          let rawValue = data[y][x];
           let fraction = (rawValue - range[0]) / (range[1] - range[0]);
           // for red, green, blue,
           for (let i = 0; i < 3; i++) {
@@ -79,25 +79,38 @@
     return rgba;
   }
 
+  function renderImageToCanvas() {
+    let chunk2d = chunk;
+    if (chunkSlice) {
+      try {
+        chunk2d = sliceArray(chunk, chunkSlice);
+        errorMsg = undefined;
+      } catch (error) {
+        errorMsg = `Slicing (${chunk.shape}) failed with slice (${chunkSlice})`;
+      }
+    }
+    if (!errorMsg) {
+      let minMax = getMinMaxValues(chunk2d);
+      minMaxMsg = `Min: ${minMax[0]} Max: ${minMax[1]}`;
+      let rgb = renderTo8bitArray([chunk2d], [minMax]);
+      ctx.putImageData(new ImageData(rgb, width, height), 0, 0);
+    }
+  }
+
   onMount(() => {
     ctx = canvas.getContext("2d");
-
-    let rgb = renderTo8bitArray([chunk], chunkSlice);
-    console.log("rgb data", rgb);
-
-    ctx.putImageData(new ImageData(rgb, width, height), 0, 0);
+    renderImageToCanvas();
   });
 
-  afterUpdate(() => {
-    console.log("Updated....");
-    let rgb = renderTo8bitArray([chunk], chunkSlice);
-    console.log("rgb data....", rgb);
-
-    ctx.putImageData(new ImageData(rgb, width, height), 0, 0);
-  });
+  afterUpdate(renderImageToCanvas);
 </script>
 
+{#if errorMsg}
+<p>{errorMsg}</p>
+{:else}
+<p>{minMaxMsg}</p>
 <canvas bind:this={canvas} {width} {height} />
+{/if}
 
 <style>
   canvas {

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
@@ -1,0 +1,91 @@
+<script>
+  import { onMount, afterUpdate } from "svelte";
+
+  export let chunk;
+
+  let canvas;
+  let ctx;
+
+  let shape = chunk.shape;
+  console.log("chunkViewer shape", chunk.shape);
+
+  const width = shape[shape.length - 1];
+  const height = shape[shape.length - 2];
+
+  function getMinMaxValues(rawChunk) {
+      // rawChunk.data is single array
+      let maxV = 0;
+      let minV = Infinity;
+      let d = rawChunk.data;
+      let size = d.length;
+      console.log('d', d);
+      for (let i = 0; i < size; i++) {
+        let v = d[i];
+          maxV = Math.max(maxV, v);
+          minV = Math.min(minV, v);
+      }
+      return [minV, maxV];
+  }
+
+  export function renderTo8bitArray(rawChunks) {
+    // rawChunks is list of zarr arrays
+
+    let minMaxValues = rawChunks.map(getMinMaxValues);
+
+    console.log('minMaxValues', minMaxValues);
+
+    let rgb = [255, 255, 255];
+
+    const height = rawChunks[0].shape[0];
+    const width = rawChunks[0].shape[1];
+    const rgba = new Uint8ClampedArray(4 * height * width).fill(0);
+    let offset = 0;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        for (let p = 0; p < rawChunks.length; p++) {
+          let data = rawChunks[p].data;
+          let range = minMaxValues[p];
+          let rawValue = data[offset];
+          let fraction = (rawValue - range[0]) / (range[1] - range[0]);
+          // for red, green, blue,
+          for (let i = 0; i < 3; i++) {
+            // lut[i] is 0-255...
+            let v = (fraction * rgb[i]) << 0;
+            // increase pixel intensity if value is higher
+            rgba[(offset * 4) + i] = Math.max(rgba[(offset * 4) + i], v);
+          }
+        }
+        rgba[(offset * 4) + 3] = 255; // alpha
+        offset += 1;
+      }
+    }
+    return rgba;
+  }
+
+  onMount(() => {
+    ctx = canvas.getContext("2d");
+
+    let rgb = renderTo8bitArray([chunk]);
+    console.log("rgb data", rgb);
+
+    ctx.putImageData(new ImageData(rgb, width, height), 0, 0);
+  });
+
+  afterUpdate(() => {
+    console.log("Updated....");
+    let rgb = renderTo8bitArray([chunk]);
+    console.log("rgb data....", rgb);
+
+    ctx.putImageData(new ImageData(rgb, width, height), 0, 0);
+  });
+</script>
+
+<canvas bind:this={canvas} {width} {height} />
+
+<style>
+  canvas {
+    max-width: 100%;
+    max-height: 100%;
+    background-color: #666;
+  }
+</style>

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/index.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/index.svelte
@@ -77,11 +77,9 @@
     margin: 15px 0;
     box-shadow: 5px 5px 10px #c3c0c0;
     background: linear-gradient(to right, #ccc, #aaa);
-  }
-
-  p {
     text-align: center;
   }
+
   pre {
     color: #faebd7;
     background-color: #2c3e50;
@@ -118,6 +116,7 @@
   details {
     font-size: 1.1em;
     margin: 0 15px;
+    text-align: left;
   }
   pre {
     margin-top: 10px;

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/index.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/index.svelte
@@ -1,16 +1,20 @@
 <script>
-  import { getJson, formatBytes } from "../../../utils";
+  import { getJson, formatBytes, range } from "../../../utils";
   import Cube3D from "./Cube3D.svelte";
+  import ChunkLoader from "./ChunkLoader.svelte";
 
   export let source;
   export let path;
 
   const promise = getJson(source + path + "/.zarray");
 
-  function chunkCount(zarray) {
+  function totalChunkCount(zarray) {
+    return chunkCounts(zarray).reduce((prev, curr) => prev * curr, 1);
+  }
+
+  function chunkCounts(zarray) {
     const ch = zarray.chunks;
-    const counts = zarray.shape.map((sh, index) => Math.ceil(sh / ch[index]));
-    return counts.reduce((prev, curr) => prev * curr, 1);
+    return zarray.shape.map((sh, index) => Math.ceil(sh / ch[index]));
   }
 
   function getBytes(shape, zarray) {
@@ -42,9 +46,9 @@
         <td>{JSON.stringify(zarray.chunks)}</td>
       </tr>
       <tr>
-        <th>Count</th>
-        <td>{chunkCount(zarray) + 1} Tasks</td>
-        <td>{chunkCount(zarray)} Chunks</td>
+        <th>Counts</th>
+        <td>{chunkCounts(zarray)}</td>
+        <td>{totalChunkCount(zarray)} Chunks</td>
       </tr>
       <tr>
         <th>Type</th>
@@ -52,6 +56,8 @@
         <td>numpy.ndarray</td>
       </tr>
     </table>
+
+    <ChunkLoader {zarray} {source} {path} />
 
     <Cube3D {zarray} />
 

--- a/src/JsonValidator/index.svelte
+++ b/src/JsonValidator/index.svelte
@@ -30,7 +30,7 @@
 <article>
   <a title="View {dtype} in vizarr" class="vizarr_link" target="_blank"
                 href="https://hms-dbmi.github.io/vizarr/?source={source}"
-                ><img src={vizarrLogoUrl}/></a>
+                ><img alt="Vizarr logo" src={vizarrLogoUrl}/></a>
 
   <!-- leave space on the right for vizarr link -->
   <p class="margin_right">


### PR DESCRIPTION
This addresses the "Load chunks with zarr.js and display" from https://github.com/ome/ome-ngff-validator/issues/6
and the feature request "how can I load a specific location in the hierarchy to check it? i.e. 1/0/0/6/10/4 and /0/0/0/8/23/2?" from https://forum.image.sc/t/error-in-import-of-ome-zarr-in-omero/74252/4

We load chunks according to the indices chosen by the user.

To test:
 - Open 
If it's a 2D chunk then it is simply displayed: E.g. https://deploy-preview-21--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.3/9836842.zarr 1 chunk per plane. 
 - Open an image with 3D chunks. E.g. https://deploy-preview-21--ome-ngff-validator.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z_dtype_fix.zarr . You get additional slider(s) to slice the chunk to 2D (see screenshot):
 - Try other sample images too!

<img width="1061" alt="Screenshot 2022-11-30 at 23 04 32" src="https://user-images.githubusercontent.com/900055/204927240-d79f70ba-8f6e-4ea1-b83d-1b7479cb16d8.png">

https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z_dtype_fix.zarr