### PR TITLE
Viewer logo fix2

### DIFF
--- a/src/Bioformats2rawLayout/index.svelte
+++ b/src/Bioformats2rawLayout/index.svelte
@@ -6,7 +6,7 @@
   export let source;
   export let rootAttrs;
 
-  const metadataName = "OME/METADATA.ome.xml";
+  const metadataName = "/OME/METADATA.ome.xml";
 
   // source/OME/METADATA.ome.xml
   const metadataUrl = `${source}${metadataName}`;

--- a/src/Bioformats2rawLayout/index.svelte
+++ b/src/Bioformats2rawLayout/index.svelte
@@ -6,10 +6,10 @@
   export let source;
   export let rootAttrs;
 
-  const metadataName = "/OME/METADATA.ome.xml";
+  const metadataName = "OME/METADATA.ome.xml";
 
   // source/OME/METADATA.ome.xml
-  const metadataUrl = `${source}${metadataName}`;
+  const metadataUrl = `${source}/${metadataName}`;
 
   async function loadXml(url) {
     let dom = await getXmlDom(url);

--- a/src/JsonValidator/OpenWithViewers/index.svelte
+++ b/src/JsonValidator/OpenWithViewers/index.svelte
@@ -1,34 +1,32 @@
 <script>
   import viewers_json from "../../../public/ngff_viewers.json";
 
+  import vizarr_logo from "/vizarr_logo.png";
+
   import CopyButton from "./CopyButton.svelte";
 
   export let source;
   export let dtype;
 
-  // Need to dynamically generate URLs for icons...
-  async function loadIcons(viewer_data) {
-    let href = viewer_data.href;
-    if (href) {
-      if (href.includes("{URL}")) {
-        href = href.replace("{URL}", source);
-      } else {
-        href += source;
+  let viewers = viewers_json.viewers.map((viewer_data) => {
+      let href = viewer_data.href;
+      if (href) {
+        if (href.includes("{URL}")) {
+          href = href.replace("{URL}", source);
+        } else {
+          href += source;
+        }
       }
-    }
-    const logo_path = (await fetch(viewer_data.logo)).url;
-    return { ...viewer_data, href, logo_path };
-  }
+      // use static import of vizarr_logo.png to get base URL for other logos
+      const logo_path = vizarr_logo.replace("/vizarr_logo.png", viewer_data.logo);
+      return {...viewer_data, href, logo_path}
+    });
 
-  const promise = Promise.all(viewers_json.viewers.map(loadIcons));
 </script>
 
 <div class="openwith">
   <span>Open with:</span>
   <ul>
-    {#await promise}
-      <p>loading...</p>
-    {:then viewers}
       {#each viewers as viewer}
         <li>
           {#if viewer.href}
@@ -57,9 +55,6 @@
             </div>{/if}
         </li>
       {/each}
-    {:catch error}
-      <span>{error}</span>
-    {/await}
   </ul>
 </div>
 


### PR DESCRIPTION
Not seen an answer at https://github.com/vitejs/vite/discussions/12121 as to how to fix the original problem.

So this is an alternative approach...
Since Vite build recognises imports to URLs if they are specified at the top, e.g. `import copy_icon from "/copy_icon.png";` for the copy icon, and this is working when URLs to other icons fail (vite creates all the paths correctly in production deploy).

So this PR uses a URL generated in this way as a basis for URLs to other icons.

This also fixes the loading of OME/METADATA.xml which was broken in #23
E.g. test with https://deploy-preview-28--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0048A/9846151.zarr/