### PR TITLE
Swap chunkX and chunkY for cube lines

### DIFF
--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/Cube3D.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/Cube3D.svelte
@@ -162,7 +162,7 @@
         rgba(70, 70, 70, 0.7) 0px,
         rgba(70, 70, 70, 0.7) 1px,
         transparent 1px,
-        transparent var(--chunkX)
+        transparent var(--chunkY)
       ),
       repeating-linear-gradient(
         90deg,

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/Cube3D.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/Cube3D.svelte
@@ -88,14 +88,14 @@
         rgba(70, 70, 70, 0.7) 0px,
         rgba(70, 70, 70, 0.7) 1px,
         transparent 1px,
-        transparent var(--chunkX)
+        transparent var(--chunkY)
       ),
       repeating-linear-gradient(
         90deg,
         rgba(70, 70, 70, 0.7) 0px,
         rgba(70, 70, 70, 0.7) 1px,
         transparent 1px,
-        transparent var(--chunkY)
+        transparent var(--chunkX)
       ),
       linear-gradient(90deg, rgb(255, 255, 255), rgb(255, 255, 255));
   }


### PR DESCRIPTION
Tiny bug fix...

The `chunkX` and `chunkY` lines drawn on the 3D cube are swapped, so that when chunks are rectangular (not square) then the chunks are "portrait" instead of "landscape" (and vice versa).
E.g: https://ome.github.io/ome-ngff-validator/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr

Here, the chunk size is the same as the shape, so we shouldn't see any chunk-divider lines, but we do:

<img width="349" alt="Screenshot 2023-05-18 at 21 57 18" src="https://github.com/ome/ome-ngff-validator/assets/900055/99e54486-af3a-4ef5-ad39-dbb21d6a3de8">

This is fixed in this PR:
https://deploy-preview-29--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0101A/13457537.zarr

![Screenshot 2023-05-22 at 14 34 25](https://github.com/ome/ome-ngff-validator/assets/900055/83833490-2745-4164-9924-d0a525397dd8)

