### PR TITLE
fix use of showSliceControls

### DIFF
--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkLoader.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkLoader.svelte
@@ -75,7 +75,7 @@
     </select>
   {/each}
 
-  {#if showChunks}
+  {#if showChunks && showSliceControls}
     <div class="sliceControls">
       Slice chunk to 2D:
       {#each chunkSlice.slice(0, -2) as cc, dim}


### PR DESCRIPTION
Reminded of this fix when showing @pwalczysko the other day...

To test:

When chunks are 2D, we don't need to show the 'slice' controls, so it should look like this:

https://deploy-preview-30--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.4/idr0062A/6001240.zarr

![Screenshot 2023-05-26 at 17 01 30](https://github.com/ome/ome-ngff-validator/assets/900055/f7dfd1ef-4a3c-4bf3-83cc-2d45f8d135a3)

When chunks are 3D, then we show the 'slice controls':

https://deploy-preview-30--ome-ngff-validator.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.4/idr0077/9836832_z_dtype_fix.zarr

![Screenshot 2023-05-26 at 17 02 45](https://github.com/ome/ome-ngff-validator/assets/900055/f626e987-10d7-4d80-90ad-0eaf1db80fb5)

