### PR TITLE
Transforms support

### DIFF
--- a/src/JsonValidator/index.svelte
+++ b/src/JsonValidator/index.svelte
@@ -42,7 +42,7 @@
   Using schema{schemaUrls.length > 1 ? "s" : ""}: 
   {#each schemaUrls as url, i}
     {i > 0 ? " and " : ""}
-    <a href={url} target="_blank">{url.split("main")[1]}</a>
+    <a href={url} target="_blank">{url.includes("main") ? url.split("main")[1] : url}</a>
   {/each}
 
   {#await promise}


### PR DESCRIPTION
Adding support for https://github.com/ome/ngff/pull/138

Since that PR isn't merged yet, we need custom URL for loading schemas from that branch.

This PR build is deployed at https://deploy-preview-32--ome-ngff-validator.netlify.app - but I don't know of good sample data to test with.

To test a sample file containing various example snippets from the PR above see https://deploy-preview-32--ome-ngff-validator.netlify.app/?source=https://minio-dev.openmicroscopy.org/idr/v0.5/idr0050/4995115.zarr

NB: this is valid according to the proposed schemas, but won't make any sense to a viewer client.

I'm not loading some schemas, such as `coordinate_systems_and_transforms.schema` and `coordinateTransformations.schema`. I'm don't see that they are needed by any validation yet, but I've not tried much.
Also the strict schemas aren't used (same as before).