### PR TITLE
Version split on dash

### DIFF
--- a/src/JsonValidator/MultiscaleArrays/Multiscale.svelte
+++ b/src/JsonValidator/MultiscaleArrays/Multiscale.svelte
@@ -4,6 +4,7 @@
 
   export let source;
   export let multiscale;
+  export let version;
 
   const WARNING = "warning";
 
@@ -11,7 +12,7 @@
   // shape.length (number of dimensions)
 
   // If multiscale.axes (version > 0.3) check it matches shape
-  const { axes, datasets, version } = multiscale;
+  const { axes, datasets } = multiscale;
 
   const permitDtypeMismatch = ["0.1", "0.2", "0.3", "0.4"].includes(version);
   const checkDimSeparator = ["0.2", "0.3", "0.4"].includes(version);

--- a/src/JsonValidator/MultiscaleArrays/index.svelte
+++ b/src/JsonValidator/MultiscaleArrays/index.svelte
@@ -13,7 +13,7 @@
 {#each rootAttrs.multiscales as multiscale, idx}
   <article>
     <h2>Multiscale {idx}</h2>
-    <Multiscale {source} {multiscale} /> 
+    <Multiscale {source} {multiscale} version={msVersion}/>
     {#each multiscale.datasets as dataset}
       <ZarrArray {source} path={dataset.path + "/" + zarrAttrsFileName} />
     {/each}

--- a/src/utils.js
+++ b/src/utils.js
@@ -139,34 +139,40 @@ export async function getSchema(schemaUrl) {
 
 export function getVersion(ngffData) {
   // if we have attributes.ome then this is version 0.5+
+  let version;
   if (ngffData.attributes?.ome) {
     if (ngffData.attributes.ome.version) {
-      return ngffData.attributes.ome.version;
+      version = ngffData.attributes.ome.version;
     } else {
       throw Error("No version found in attributes.ome");
     }
   }
 
   // Used if we have our 'attributes' at the root
-  if (ngffData.ome?.version) {
-    return ngffData.ome.version;
+  else if (ngffData.ome?.version) {
+    version = ngffData.ome.version;
   }
-  if (ngffData.version) {
-    return ngffData.version;
+  else if (ngffData.version) {
+    version = ngffData.version;
   }
   // Handle version 0.4 and earlier
-  let version = ngffData.multiscales
-    ? ngffData.multiscales[0].version
-    : ngffData.plate
-    ? ngffData.plate.version
-    : ngffData.well
-    ? ngffData.well.version
-    : undefined;
+  else {
+    version = ngffData.multiscales
+      ? ngffData.multiscales[0].version
+      : ngffData.plate
+      ? ngffData.plate.version
+      : ngffData.well
+      ? ngffData.well.version
+      : undefined;
+  }
   console.log("version", version);
   // for 0.4 and earlier, version wasn't MUST and we defaulted
   // to using v0.4 for validation. To preserve that behaviour
   // return "0.4" if no version found.
-  return version || "0.4";
+  version = version || "0.4";
+
+  // remove any -dev2 etc.
+  return version.split("-")[0];
 }
 
 export function toTitleCase(text) {


### PR DESCRIPTION
This contributes to the discussion at https://github.com/scverse/spatialdata/pull/849

This partially allows versions such as `0.4-dev1` etc by simply ignoring everything after the `-`.

This fix allows us to load the appropriate schemas for validation, e.g.https://raw.githubusercontent.com/ome/ngff/main/0.4/schemas/image.schema
 
However, this results in validation errors since the schema there specifies that the version MUST be `0.4`:

![Screenshot 2025-02-04 at 10 29 52](https://github.com/user-attachments/assets/d738b40c-debf-4a25-bfa4-dc330cd26af3)

