### PR TITLE
limit size of thumbnail to 300px

### DIFF
--- a/src/Bioformats2rawLayout/index.svelte
+++ b/src/Bioformats2rawLayout/index.svelte
@@ -140,7 +140,7 @@
               </div>
               <div class="thumbnail_wrapper">
                 <a title="Open Image in Validator" href="{url}?source={source}/{image.path}/">
-                <Thumbnail source={`${source}/${image.path}`} targetSize=100 />
+                <Thumbnail source={`${source}/${image.path}`} targetSize=100 maxCssSize=100 />
                 </a>
               </div>
             </li>
@@ -219,8 +219,6 @@
   }
 
   .thumbnail_wrapper :global(.thumbnail) {
-    max-width: 100px;
-    max-height: 100px;
     border-radius: 5px;
   }
 </style>

--- a/src/JsonValidator/Thumbnail/index.svelte
+++ b/src/JsonValidator/Thumbnail/index.svelte
@@ -5,6 +5,7 @@
   export let source;
   // Default target size 0 will get thumbnail from smallest resolution
   export let targetSize = 0;
+  export let maxCssSize = 250;
 
   const store = new zarr.FetchStore(source);
   const promise = omezarr.renderThumbnail(store, targetSize);
@@ -20,7 +21,7 @@
     />
   </div>
 {:then src}
-  <img {src} alt="Thumbnail" class="thumbnail" />
+  <img {src} alt="Thumbnail" class="thumbnail" style="--max-css-size: {maxCssSize}px" />
 {:catch error}
   <div title="Failed to load thumbnail: {error.message}" class="failed">
     <img
@@ -83,7 +84,8 @@
     animation: spinner 1s linear infinite;
   }
   .thumbnail {
-    max-width: 300px;
-    max-height: 300px;
+    border-radius: 5px;
+    max-width: var(--max-css-size);
+    max-height: var(--max-css-size);
   }
 </style>

--- a/src/JsonValidator/Thumbnail/index.svelte
+++ b/src/JsonValidator/Thumbnail/index.svelte
@@ -82,4 +82,8 @@
     border-top-color: rgba(0, 0, 0, 0.6);
     animation: spinner 1s linear infinite;
   }
+  .thumbnail {
+    max-width: 300px;
+    max-height: 300px;
+  }
 </style>

--- a/src/JsonValidator/index.svelte
+++ b/src/JsonValidator/index.svelte
@@ -66,7 +66,7 @@
 
 <article>
   <div class="thumbnail_wrapper">
-    <Thumbnail source = {firstPlateImageUrl || firstWellImageUrl || source} targetSize=150 />
+    <Thumbnail source = {firstPlateImageUrl || firstWellImageUrl || source} targetSize=150 maxCssSize=300 />
   </div>
 
   <p>


### PR DESCRIPTION
E.g. see https://ome.github.io/ome-ngff-validator/?source=https://storage.googleapis.com/jax-public-ngff-2024/public_data/1573/whitej_205/2020-08/18/16-33-38.939/KOMP_K2755_8.zarr/0/ has large thumbnail.

This limits it to max 300px wide/high.

To test:

https://deploy-preview-50--ome-ngff-validator.netlify.app/?source=https://storage.googleapis.com/jax-public-ngff-2024/public_data/1573/whitej_205/2020-08/18/16-33-38.939/KOMP_K2755_8.zarr/0/