### PR TITLE
Bump ome zarr.js 0.0.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "ajv": "^8.11.0",
         "ndarray": "^1.0.19",
-        "ome-zarr.js": "^0.0.11",
+        "ome-zarr.js": "^0.0.14",
         "svelte-icons-pack": "^1.4.6",
         "svelte-simple-modal": "^1.4.1",
         "zarrita": "^0.5.0"
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/ome-zarr.js": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.11.tgz",
-      "integrity": "sha512-2VsX0FxJ0FI3Ch11rmOzsERbbHIE5U18YmZR9zC0wGKsx1H9pTxZl1S2QbeuuTYGg/8T3rNGTkPLzU3ET6q4Xw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.14.tgz",
+      "integrity": "sha512-j7EMcZXJOUdqZI5LNj+rtTOhMBN/ac2TUGq/V5avawdTxGCGXjsZsZRR7YKq2YmdyQQit2tF1Vm1OnIDL22fjg==",
       "license": "BSD",
       "dependencies": {
         "zarrita": "^0.5.0"
@@ -1180,9 +1180,9 @@
       }
     },
     "ome-zarr.js": {
-      "version": "0.0.11",
-      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.11.tgz",
-      "integrity": "sha512-2VsX0FxJ0FI3Ch11rmOzsERbbHIE5U18YmZR9zC0wGKsx1H9pTxZl1S2QbeuuTYGg/8T3rNGTkPLzU3ET6q4Xw==",
+      "version": "0.0.14",
+      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.14.tgz",
+      "integrity": "sha512-j7EMcZXJOUdqZI5LNj+rtTOhMBN/ac2TUGq/V5avawdTxGCGXjsZsZRR7YKq2YmdyQQit2tF1Vm1OnIDL22fjg==",
       "requires": {
         "zarrita": "^0.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "ndarray": "^1.0.19",
-    "ome-zarr.js": "^0.0.11",
+    "ome-zarr.js": "^0.0.14",
     "svelte-icons-pack": "^1.4.6",
     "svelte-simple-modal": "^1.4.1",
     "zarrita": "^0.5.0"

--- a/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
+++ b/src/JsonValidator/MultiscaleArrays/ZarrArray/ChunkViewer.svelte
@@ -23,7 +23,7 @@
     let minV = Infinity;
     for (let y = 0; y < height; y++) {
       for (let x = 0; x < width; x++) {
-        let rawValue = chunk2d.get(y, x);
+        let rawValue = Number(chunk2d.get(y, x));
         maxV = Math.max(maxV, rawValue);
         minV = Math.min(minV, rawValue);
       }
@@ -68,7 +68,7 @@
       for (let x = 0; x < width; x++) {
         for (let p = 0; p < ndChunks.length; p++) {
           let range = minMaxValues[p];
-          let rawValue = ndChunks[p].get(y, x);
+          let rawValue = Number(ndChunks[p].get(y, x));
           let fraction = (rawValue - range[0]) / (range[1] - range[0]);
           // for red, green, blue,
           for (let i = 0; i < 3; i++) {


### PR DESCRIPTION
Fixes rendering of int64 (BigInt) data for thumbnail and chunks - e.g failing at https://ome.github.io/ome-ngff-validator/?source=https://s3.janelia.org/funceworm/test-uint64.zarr/

 - updates ome-zarr.js to 0.0.14
 - Fixes rendering of chunks by casting values to Number

Test at https://deploy-preview-53--ome-ngff-validator.netlify.app/?source=https://s3.janelia.org/funceworm/test-uint64-small.zarr/

Thumbnail should render at the top of the page.
Also, "load chunks" should render.

NB: screenshot is with a different sample

<img width="1221" height="1003" alt="Screenshot 2025-08-20 at 14 50 40" src="https://github.com/user-attachments/assets/b5d68ae3-c6f6-4be6-b529-c5358f98208c" />
