### PR TITLE
Try .zattrs if zarr.json gives 404 or CORS errors

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -82,10 +82,12 @@ async function getZarrJson(zarr_dir, alternative=".zattrs") {
     zarrJson = await getJson(zarr_dir + "/zarr.json");
   } catch (error) {
     console.log("getZarrJson", error)
-    if (!error.message.includes(FILE_NOT_FOUND)) {
+    // If it's not a CORS or 404 error, then re-throw
+    if (!error.message.includes("CORS") && !error.message.includes(FILE_NOT_FOUND)) {
       throw error;
     }
-    // IF we got a 404 then try other URL
+    // We might have a CORS error just because of 404 (on some servers)
+    // In either case, it's worth trying other URL
     try {
       zarrJson = await getJson(zarr_dir + `/${alternative}`);
     } catch (err2) {


### PR DESCRIPTION
Fixes https://forum.image.sc/t/vizarr-ngff-validator-cors-issue-with-404-error/116062/10
This improves opening of zarr v2 data on servers where a 404 response doesn't have correct CORS headers.

Previously, since we don't know if we have zarr v3 or zarr v2 data, we first try to load `zarr.json` and if we get a 404, then we try to load `.zattrs` or `.zarray`.

But, CORS errors were handled differently - with CORS message.

Now, if we get a CORS error (or 404) for `zarr.json` then we still try to load `.zattrs` or `.zarray`.
If this fails then it will be reported as CORS error on a server that doesn't set CORS headers for 404.