### PR TITLE
Update neuroglancer URL and enable for OME-Zarr v0.5

### DIFF
--- a/public/ngff_viewers.json
+++ b/public/ngff_viewers.json
@@ -17,7 +17,7 @@
       "href": "https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22{URL}%22,%22name%22:%22OME-NGFF%22}]}"
     },
     {
-      "name": "Allen Cell 3D viewer",
+      "name": "Vol-E viewer",
       "logo": "/aics_website-3d-cell-viewer.png",
       "href": "https://volumeviewer.allencell.org/viewer?url="
     },

--- a/public/ngff_viewers.json
+++ b/public/ngff_viewers.json
@@ -14,7 +14,7 @@
       "name": "neuroglancer",
       "logo": "/neuroglancer.png",
       "//": "NB: The {URL} in the href is replaced with NGFF image URL",
-      "href": "https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22zarr://{URL}%22,%22name%22:%22OME-NGFF%22}]}"
+      "href": "https://neuroglancer-demo.appspot.com/#!{%22layers%22:[{%22source%22:%22{URL}%22,%22name%22:%22OME-NGFF%22}]}"
     },
     {
       "name": "Allen Cell 3D viewer",

--- a/src/JsonValidator/OpenWithViewers/index.svelte
+++ b/src/JsonValidator/OpenWithViewers/index.svelte
@@ -25,7 +25,7 @@
 
     if (version == "0.5") {
       // TODO: update when other viewers support zarr v3
-      viewers = viewers.filter((viewer) => viewer.name == "vizarr");
+      viewers = viewers.filter((viewer) => viewer.name != "itk-vtk-viewer");
     }
 
 </script>


### PR DESCRIPTION
This updates the URL format used for neuroglancer - it doesn't need to distinguish between Zarr v2 and v3 now.
OME-Zarr v0.5 images now have all Open-with optioned enabled (except VTK-ITK viewer which doesn't seem to work with Zarr v3).

Also, neuroglancer does a much nicer job of handling multi-channel images now.

See https://github.com/google/neuroglancer/issues/541#issuecomment-3254901751

To test, open images (including v0.5 images) with: e.g.
 
https://deploy-preview-55--ome-ngff-validator.netlify.app/?source=https://uk1s3.embassy.ebi.ac.uk/idr/zarr/v0.5/idr0062A/6001240_labels.zarr  and open with neuroglancer and Vol-E viewer (tooltip name has been updated too).