### PR TITLE
start to try support ZipStore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ome-ngff-validator",
       "version": "0.3.0",
       "dependencies": {
+        "@zarrita/storage": "^0.1.3",
         "ajv": "^8.11.0",
         "ndarray": "^1.0.19",
         "ome-zarr.js": "^0.0.14",
@@ -62,9 +63,9 @@
       }
     },
     "node_modules/@zarrita/storage": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.1.tgz",
-      "integrity": "sha512-6/NUCvpzsIxfxeMv59jRTl/bOZg3GZfMP6iR8EIqrTaaE0S2jLL/ceX1OxcFBKnuA8/Z2YmgX4SFBHwFGrCcsw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.3.tgz",
+      "integrity": "sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==",
       "license": "MIT",
       "dependencies": {
         "reference-spec-reader": "^0.2.0",
@@ -871,9 +872,9 @@
       }
     },
     "@zarrita/storage": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.1.tgz",
-      "integrity": "sha512-6/NUCvpzsIxfxeMv59jRTl/bOZg3GZfMP6iR8EIqrTaaE0S2jLL/ceX1OxcFBKnuA8/Z2YmgX4SFBHwFGrCcsw==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@zarrita/storage/-/storage-0.1.3.tgz",
+      "integrity": "sha512-ZyCMYN3LuCNtKxro9876r/KyHyXV+ie2Bhk1qYsJR4Jp+sAjoVRRNNSJPsJxk64ZgFFezayO5S2hCu88/1Odwg==",
       "requires": {
         "reference-spec-reader": "^0.2.0",
         "unzipit": "^1.4.3"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "vite": "^2.9.9"
   },
   "dependencies": {
+    "@zarrita/storage": "^0.1.3",
     "ajv": "^8.11.0",
     "ndarray": "^1.0.19",
     "ome-zarr.js": "^0.0.14",

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,9 @@
 
 import Ajv from "ajv";
 
+import * as zarrita from "zarrita";
+import { ZipFileStore } from "@zarrita/storage";
+
 export const CURRENT_VERSION = "0.5";
 export const FILE_NOT_FOUND = "File not found";
 
@@ -16,20 +19,29 @@ async function fetchHandleError(url) {
   let msg = `Error Loading ${url}:`;
   let rsp;
   try {
-    rsp = await fetch(url).then(function (response) {
-      if (!response.ok) {
-        // make the promise be rejected if we didn't get a 2xx response
-        // NB. statusText could be "Not Found" or "File not found" depending on server
-        // Standardise based on response.status
-        if (response.status == 404) {
-          msg += ` ${FILE_NOT_FOUND}`;
-        } else {
-          msg += ` ${response.statusText}`;
-        }
-      } else {
-        return response;
-      }
-    });
+    console.log("fetchHandleError url", url);
+
+    const store = ZipFileStore.fromUrl(url);
+    console.log("ZipFileStore", store);
+    const group = await zarrita.open(store, { kind: "group" });
+    console.log("ZipFileStore group", group);
+    return group.attrs;
+    // const metadata = JSON.stringify(group.attrs, null, 2);
+
+    // rsp = await fetch(url).then(function (response) {
+    //   if (!response.ok) {
+    //     // make the promise be rejected if we didn't get a 2xx response
+    //     // NB. statusText could be "Not Found" or "File not found" depending on server
+    //     // Standardise based on response.status
+    //     if (response.status == 404) {
+    //       msg += ` ${FILE_NOT_FOUND}`;
+    //     } else {
+    //       msg += ` ${response.statusText}`;
+    //     }
+    //   } else {
+    //     return response;
+    //   }
+    // });
   } catch (error) {
     console.log("check for CORS...");
     console.log(error);


### PR DESCRIPTION
Based on https://github.com/jwindhager/ngff-rfc9-zipped-ome-zarr/blob/main/playground/zarrita.js/src/main.ts

Tried to start support for zip store with 

http://localhost:3000/?source=https://static.webknossos.org/misc/6001240.ozx

However, this fails with:

```
$ npm run dev

> ome-ngff-validator@0.3.0 dev
> vite


  vite v2.9.9 dev server running at:

  > Local: http://localhost:3000/
  > Network: use `--host` to expose

  ready in 268ms.

8:36:35 PM [vite-plugin-svelte] /Users/wmoore/Desktop/NGFF/ome-ngff-validator/src/JsonValidator/RoCrate/RoCrateValidator.svelte:116:4 Unused CSS selector ".suggested"
✘ [ERROR] No matching export in "browser-external:node:buffer" for import "Buffer"

    node_modules/@zarrita/storage/dist/src/fs.js:1:9:
      1 │ import { Buffer } from "node:buffer";
        ╵          ~~~~~~

8:36:35 PM [vite] error while updating dependencies:
Error: Build failed with 1 error:
node_modules/@zarrita/storage/dist/src/fs.js:1:9: ERROR: No matching export in "browser-external:node:buffer" for import "Buffer"
    at failureErrorWithLog (/Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:1603:15)
    at /Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:1249:28
    at runOnEndCallbacks (/Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:1034:63)
    at buildResponseToResult (/Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:1247:7)
    at /Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:1356:14
    at /Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:666:9
    at handleIncomingPacket (/Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:763:9)
    at Socket.readFromStdout (/Users/wmoore/Desktop/NGFF/ome-ngff-validator/node_modules/esbuild/lib/main.js:632:7)
    at Socket.emit (node:events:524:28)
    at addChunk (node:internal/streams/readable:561:12)
Vite Error, /node_modules/.vite/deps/ajv.js?v=581543dd optimized info should be defined
Vite Error, /node_modules/.vite/deps/svelte-icons-pack_bs_BsCaretRightFill.js?v=a46f27b5 optimized info should be defined
Vite Error, /node_modules/.vite/deps/svelte_transition.js?v=73cdd73d optimized info should be defined
Vite Error, /node_modules/.vite/deps/svelte_transition.js?v=73cdd73d optimized info should be defined (x2)
Vite Error, /node_modules/.vite/deps/@zarrita_storage.js?v=6bbe44b2 optimized info should be defined
Vite Error, /node_modules/.vite/deps/ajv.js?v=581543dd optimized info should be defined
Vite Error, /node_modules/.vite/deps/@zarrita_storage.js?v=6bbe44b2 optimized info should be defined
8:36:35 PM [vite-plugin-svelte] /Users/wmoore/Desktop/NGFF/ome-ngff-validator/src/JsonValidator/RoCrate/RoCrateValidator.svelte:116:4 Unused CSS selector ".suggested"
Vite Error, /node_modules/.vite/deps/svelte_transition.js?v=73cdd73d optimized info should be defined
Vite Error, /node_modules/.vite/deps/svelte-icons-pack_bs_BsCaretRightFill.js?v=a46f27b5 optimized info should be defined
Vite Error, /node_modules/.vite/deps/svelte_transition.js?v=73cdd73d optimized info should be defined
files in the public directory are served at the root path.
Instead of /public/ngff_viewers.json?import, use /ngff_viewers.json?import.
files in the public directory are served at the root path.
Instead of /public/ngff_viewers.json?import, use /ngff_viewers.json?import. (x2)
files in the public directory are served at the root path.
Instead of /public/ngff_viewers.json?import, use /ngff_viewers.json?import. (x3)
```
