### PR TITLE
Add support for zarr-conventions thumbnails extension

### DIFF
--- a/src/JsonValidator/Thumbnail/index.svelte
+++ b/src/JsonValidator/Thumbnail/index.svelte
@@ -17,33 +17,37 @@
   // Per zarr-conventions spec, a convention can be identified by uuid, name,
   // schema_url, or spec_url. We check all since only one is required.
   function hasThumbnailsConvention(conventions) {
-    return conventions?.some(c => 
-      c.uuid === THUMBNAILS_UUID ||
-      c.name === THUMBNAILS_NAME ||
-      c.schema_url?.includes("/thumbnails/") ||
-      c.spec_url?.includes("/thumbnails/")
+    return conventions?.some(
+      (c) =>
+        c.uuid === THUMBNAILS_UUID ||
+        c.name === THUMBNAILS_NAME ||
+        c.schema_url?.includes("/thumbnails/") ||
+        c.spec_url?.includes("/thumbnails/"),
     );
   }
 
   async function loadThumbnail() {
     // Get attrs (use passed or fetch)
-    const attrs = rootAttrs || await getZarrGroupAttrs(source);
+    const attrs = rootAttrs || (await getZarrGroupAttrs(source));
     const zarrAttrs = attrs?.attributes || attrs;
-    
+
     // Check for thumbnails convention
     const conventions = zarrAttrs?.zarr_conventions || [];
-    
-    if (hasThumbnailsConvention(conventions) && zarrAttrs?.thumbnails?.length > 0) {
+
+    if (
+      hasThumbnailsConvention(conventions) &&
+      zarrAttrs?.thumbnails?.length > 0
+    ) {
       const best = selectBestThumbnail(zarrAttrs.thumbnails, 512);
       if (best) {
-        if (best.url) {
-          return best.url;
-        } else if (best.path) {
+        if (best.path) {
           return `${source}/${best.path}`;
+        } else if (best.url) {
+          return best.url;
         }
       }
     }
-    
+
     // Fallback to ome-zarr rendering
     const store = new zarr.FetchStore(source);
     return omezarr.renderThumbnail(store, targetSize);
@@ -62,7 +66,12 @@
     />
   </div>
 {:then src}
-  <img {src} alt="Thumbnail" class="thumbnail" style="--max-css-size: {maxCssSize}px" />
+  <img
+    {src}
+    alt="Thumbnail"
+    class="thumbnail"
+    style="--max-css-size: {maxCssSize}px"
+  />
 {:catch error}
   <div title="Failed to load thumbnail: {error.message}" class="failed">
     <img
@@ -88,7 +97,7 @@
     position: relative;
     width: 100px;
     height: 100px;
-    display: inline-block
+    display: inline-block;
   }
   .failed img {
     top: 0;
@@ -103,7 +112,8 @@
     font-size: 3em;
     color: darkgrey;
   }
-  .spinner img, .failed img {
+  .spinner img,
+  .failed img {
     background-color: #ddd;
     width: 100px;
     height: 100px;

--- a/src/JsonValidator/Thumbnail/index.svelte
+++ b/src/JsonValidator/Thumbnail/index.svelte
@@ -1,14 +1,55 @@
 <script>
   import * as zarr from "zarrita";
   import * as omezarr from "ome-zarr.js";
+  import { selectBestThumbnail, getZarrGroupAttrs } from "../../utils";
 
   export let source;
   // Default target size 0 will get thumbnail from smallest resolution
   export let targetSize = 0;
   export let maxCssSize = 250;
+  // Optional: pass rootAttrs to avoid re-fetching
+  export let rootAttrs = null;
 
-  const store = new zarr.FetchStore(source);
-  const promise = omezarr.renderThumbnail(store, targetSize);
+  // Convention identifiers
+  const THUMBNAILS_UUID = "49326c01-1180-4743-b15f-f7157038a6ab";
+  const THUMBNAILS_NAME = "thumbnails";
+
+  // Per zarr-conventions spec, a convention can be identified by uuid, name,
+  // schema_url, or spec_url. We check all since only one is required.
+  function hasThumbnailsConvention(conventions) {
+    return conventions?.some(c => 
+      c.uuid === THUMBNAILS_UUID ||
+      c.name === THUMBNAILS_NAME ||
+      c.schema_url?.includes("/thumbnails/") ||
+      c.spec_url?.includes("/thumbnails/")
+    );
+  }
+
+  async function loadThumbnail() {
+    // Get attrs (use passed or fetch)
+    const attrs = rootAttrs || await getZarrGroupAttrs(source);
+    const zarrAttrs = attrs?.attributes || attrs;
+    
+    // Check for thumbnails convention
+    const conventions = zarrAttrs?.zarr_conventions || [];
+    
+    if (hasThumbnailsConvention(conventions) && zarrAttrs?.thumbnails?.length > 0) {
+      const best = selectBestThumbnail(zarrAttrs.thumbnails, 512);
+      if (best) {
+        if (best.url) {
+          return best.url;
+        } else if (best.path) {
+          return `${source}/${best.path}`;
+        }
+      }
+    }
+    
+    // Fallback to ome-zarr rendering
+    const store = new zarr.FetchStore(source);
+    return omezarr.renderThumbnail(store, targetSize);
+  }
+
+  const promise = loadThumbnail();
 </script>
 
 {#await promise}

--- a/src/JsonValidator/ZarrConventions/ZarrConventionsTooltip.svelte
+++ b/src/JsonValidator/ZarrConventions/ZarrConventionsTooltip.svelte
@@ -1,0 +1,119 @@
+<script>
+    let show = false;
+    let hideTimeout;
+
+    function showTooltip() {
+        clearTimeout(hideTimeout);
+        show = true;
+    }
+
+    function hideTooltip() {
+        hideTimeout = setTimeout(() => (show = false), 400);
+    }
+</script>
+
+<button
+    type="button"
+    class="tooltip"
+    on:mouseenter={showTooltip}
+    on:mouseleave={hideTooltip}
+    on:focus={showTooltip}
+    on:blur={hideTooltip}
+>
+    <svg class="icon" width="18" height="18" viewBox="0 0 24 24">
+        <circle
+            cx="12"
+            cy="12"
+            r="10"
+            stroke="#343a40"
+            stroke-width="2.6"
+            opacity="0.9"
+            fill="none"
+        />
+        <text
+            x="12.2"
+            y="17.4"
+            text-anchor="middle"
+            font-size="15"
+            opacity="0.9"
+            fill="#343a40">?</text
+        >
+    </svg>
+
+    {#if show}
+        <p class="tooltip-content">
+            Zarr Conventions are not required, but may declare extra
+            features such as thumbnails or additional metadata assets.
+            <a
+                href="https://github.com/zarr-conventions/zarr-conventions-spec"
+                target="_blank"
+            >
+                More details →
+            </a><slot />
+        </p>
+    {/if}
+</button>
+
+<style>
+    .tooltip {
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        margin-left: 4px;
+
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: help;
+    }
+
+    .tooltip:focus-visible {
+        outline: 2px solid #fff;
+        outline-offset: 2px;
+    }
+
+    .tooltip-content {
+        font-weight: normal;
+
+        position: absolute;
+        opacity: 0.95;
+        top: 28px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 240px;
+
+        background: #263749;
+        backdrop-filter: blur(4px);
+
+        padding: 10px 12px;
+        border-radius: 6px;
+        color: #fff;
+        font-size: 0.86rem;
+        line-height: 1.35;
+
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+        z-index: 20;
+
+        animation: fadeIn 120ms ease-out 120ms;
+    }
+
+    .tooltip-content a {
+        color: #a7d8ff;
+        text-decoration: none;
+    }
+
+    .tooltip-content a:hover {
+        text-decoration: underline;
+    }
+
+    @keyframes fadeIn {
+        from {
+            opacity: 0;
+            transform: translate(-50%, -2px);
+        }
+        to {
+            opacity: 1;
+            transform: translate(-50%, 0);
+        }
+    }
+</style>

--- a/src/JsonValidator/ZarrConventions/index.svelte
+++ b/src/JsonValidator/ZarrConventions/index.svelte
@@ -1,105 +1,129 @@
-    <script>
-    import ZarrConventionsTooltip from "./ZarrConventionsTooltip.svelte";
-    import JsonBrowser from "../../JsonBrowser/index.svelte";
+<script>
+import ZarrConventionsTooltip from "./ZarrConventionsTooltip.svelte";
+import JsonBrowser from "../../JsonBrowser/index.svelte";
+export let source;
+export let rootAttrs;
+const zarrAttrs = rootAttrs?.attributes || rootAttrs;
+const attrKeys = Object.keys(zarrAttrs);
+const conventions = zarrAttrs?.zarr_conventions || [];
+const assets = zarrAttrs?.metadata_assets || [];
+const isAbsolute = (href) => /^https?:\/\//i.test(href) || href?.startsWith("/");
+const assetUrl = (href) => (isAbsolute(href) ? href : `${source}/${href}`);
+const kindMap = {
+    "ro-crate": "https://www.researchobject.org/ro-crate/",
+    "croissant": "https://docs.mlcommons.org/croissant/",
+    "ome-xml": "https://ome-model.readthedocs.io/en/stable/ome-xml/",
+    "czi-xml": "https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html",
+    "datapackage": "https://datapackage.org/",
+};
 
-    export let source;
-    export let rootAttrs;
-
-    const zarrAttrs = rootAttrs?.attributes || rootAttrs;
-
-    const conventions = zarrAttrs?.zarr_conventions || [];
-    const assets = zarrAttrs?.metadata_assets || [];
-
-    const isAbsolute = (href) => /^https?:\/\//i.test(href) || href?.startsWith("/");
-    const assetUrl = (href) => (isAbsolute(href) ? href : `${source}/${href}`);
-
-    const kindMap = {
-        "ro-crate": "https://www.researchobject.org/ro-crate/",
-        "croissant": "https://docs.mlcommons.org/croissant/",
-        "ome-xml": "https://ome-model.readthedocs.io/en/stable/ome-xml/",
-        "czi-xml": "https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html",
-        "datapackage": "https://datapackage.org/",
-    }
-    </script>
-
-    <div class="zarr-conventions">
-    {#if conventions.length > 0}
-        <h3>
-        Zarr Conventions found: {conventions.length}
-        <ZarrConventionsTooltip></ZarrConventionsTooltip>
-        </h3>
-        <div class="json">
-        <JsonBrowser
-        name=""
-        contents={{ "zarr_conventions": conventions }}
-        expanded={false}
-        />
-        </div>
-        {#if assets.length > 0}
-        <h3>Metadata assets</h3>
-        <div class="metadata-assets">
-        <ul>
-            {#each assets as asset}
-            <li>
-                <a href={assetUrl(asset.href)} target="_blank">{asset.href}</a>
-                {#if asset.kind}
-                    {#if kindMap[asset.kind]}
-                        <span class="badge"><a href={kindMap[asset.kind]} target="_blank">{asset.kind}</a></span>
-                    {:else}
-                        <span class="badge">{asset.kind}</span>
-                    {/if}
-                {/if}
-                </li>
-            {/each}
-        </ul>
-        </div>
-        {/if}
-    {:else}
-        <p>No Zarr Conventions found <ZarrConventionsTooltip></ZarrConventionsTooltip></p>
-    {/if}
+// For each convention: collect its name (if present) and check whether
+// that name actually appears in the root attributes. A convention that's
+// stated but has no matching key is "stated but not used".
+const names = conventions.map((c) => c.name).filter(Boolean);
+const unusedConventions = conventions.filter(
+    (c) => c.name && !(c.name in zarrAttrs)
+);
+</script>
+<div class="zarr-conventions">
+{#if conventions.length > 0}
+    <h3>
+    Zarr Conventions found: {conventions.length}
+    <ZarrConventionsTooltip></ZarrConventionsTooltip>
+    </h3>
+    <div class="json">
+    <JsonBrowser
+    name=""
+    contents={{ "zarr_conventions": conventions }}
+    expanded={false}
+    />
     </div>
 
-    <style>
+{#each conventions as convention}
 
-    .metadata-assets ul {
-        list-style: none;
-        margin: 10px 0;
-        text-align: left;
-        display: inline-block;
-    }
+        {#if convention.name}
+            <p>Convention name: <code>{convention.name}</code></p>
+            {#if !(convention.name in zarrAttrs)}
+                <p class="warning">
+                  <code>{convention.name}</code> not found in root attributes
+                </p>
+                <p>Attributes:
+                    <div class="json">
+    <JsonBrowser
+    name=""
+    contents={attrKeys}
+    expanded
+    />
+    </div>
+            {/if}
+        {:else}
+            <p>(No name provided for convention)</p>
+        {/if}
+    {/each}
 
-    .json {
-        text-align: left;
-        margin-top: 10px;
-        margin: 15px;
-        margin-bottom: 20px;
-        color: #faebd7;
-        background-color: #263749;
-        padding: 20px;
-        font-size: 14px;
-        border-radius: 10px;
-        font-family: monospace;
-    }
-
-
-    .zarr-conventions {
-        border-radius: 10px;
-        padding: 15px 0;
-        margin: 15px 0;
-        margin-top: 30px;
-        margin-bottom: 30px;
-        box-shadow: 5px 5px 10px #c3c0c0;
-        background: linear-gradient(to right, #ccc, #aaa);
-        text-align: center;
-    }
-
-    .badge {
-        display: inline-block;
-        margin-left: 8px;
-        padding: 2px 8px;
-        font-size: 0.8em;
-        border-radius: 10px;
-        background-color: #6e6c6c60;
-        color: rgb(27, 27, 27)000;
-    }
-    </style>
+    {#if assets.length > 0}
+    <h3>Metadata assets</h3>
+    <div class="metadata-assets">
+    <ul>
+        {#each assets as asset}
+        <li>
+            <a href={assetUrl(asset.href)} target="_blank">{asset.href}</a>
+            {#if asset.kind}
+                {#if kindMap[asset.kind]}
+                    <span class="badge"><a href={kindMap[asset.kind]} target="_blank">{asset.kind}</a></span>
+                {:else}
+                    <span class="badge">{asset.kind}</span>
+                {/if}
+            {/if}
+            </li>
+        {/each}
+    </ul>
+    </div>
+    {/if}
+{:else}
+    <p>No Zarr Conventions found <ZarrConventionsTooltip></ZarrConventionsTooltip></p>
+{/if}
+</div>
+<style>
+.metadata-assets ul {
+    list-style: none;
+    margin: 10px 0;
+    text-align: left;
+    display: inline-block;
+}
+.json {
+    text-align: left;
+    margin-top: 10px;
+    margin: 15px;
+    margin-bottom: 20px;
+    color: #faebd7;
+    background-color: #263749;
+    padding: 20px;
+    font-size: 14px;
+    border-radius: 10px;
+    font-family: monospace;
+}
+.zarr-conventions {
+    border-radius: 10px;
+    padding: 15px 0;
+    margin: 15px 0;
+    margin-top: 30px;
+    margin-bottom: 30px;
+    box-shadow: 5px 5px 10px #c3c0c0;
+    background: linear-gradient(to right, #ccc, #aaa);
+    text-align: center;
+}
+.warning {
+    color: #8a761c;
+    font-weight: bold;
+}
+.badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    font-size: 0.8em;
+    border-radius: 10px;
+    background-color: #6e6c6c60;
+    color: rgb(27, 27, 27);
+}
+</style>

--- a/src/JsonValidator/ZarrConventions/index.svelte
+++ b/src/JsonValidator/ZarrConventions/index.svelte
@@ -1,0 +1,81 @@
+<script>
+  import DetailsPrePanel from "../../JsonBrowser/DetailsPrePanel.svelte";
+  import ZarrConventionsTooltip from "./ZarrConventionsTooltip.svelte";
+
+  export let source;
+  export let rootAttrs;
+
+  const zarrAttrs = rootAttrs?.attributes || rootAttrs;
+  const conventions = zarrAttrs?.zarr_conventions || [];
+  // Per spec README, only the underscore key "metadata_assets" is valid.
+  const assets = zarrAttrs?.metadata_assets || [];
+
+  const isAbsolute = (href) => /^https?:\/\//i.test(href) || href?.startsWith("/");
+  const assetUrl = (href) => (isAbsolute(href) ? href : `${source}/${href}`);
+</script>
+
+<div class="zarr-conventions">
+  {#if conventions.length > 0}
+    <h2>
+      Zarr Conventions found: {conventions.length}
+      <ZarrConventionsTooltip></ZarrConventionsTooltip>
+    </h2>
+    <DetailsPrePanel jsonData={conventions} summary="zarr_conventions" />
+
+    {#if assets.length > 0}
+      <h3>Metadata assets</h3>
+      <ul>
+        {#each assets as asset}
+          <li>
+            <a href={assetUrl(asset.href)} target="_blank">{asset.href}</a>
+            {#if asset.kind}<span class="badge">{asset.kind}</span>{/if}
+            {#if asset.media_type}<span class="badge">{asset.media_type}</span>{/if}
+            {#if asset.attributes}
+              <DetailsPrePanel jsonData={asset.attributes} summary="attributes" />
+            {/if}
+          </li>
+        {/each}
+      </ul>
+    {/if}
+  {:else}
+    <p>No Zarr Conventions found <ZarrConventionsTooltip></ZarrConventionsTooltip></p>
+  {/if}
+</div>
+
+<style>
+  .zarr-conventions {
+    border-radius: 10px;
+    padding: 15px 0;
+    margin: 15px 0;
+    box-shadow: 5px 5px 10px #c3c0c0;
+    background: linear-gradient(to right, #ccc, #aaa);
+    text-align: center;
+  }
+
+  .zarr-conventions ul {
+    list-style: none;
+    padding: 0;
+    margin: 10px 0;
+    text-align: left;
+    display: inline-block;
+  }
+
+  .zarr-conventions li {
+    margin: 6px 0;
+  }
+
+  .zarr-conventions a,
+  .zarr-conventions a:visited {
+    color: var(--omeLinkBlue);
+  }
+
+  .badge {
+    display: inline-block;
+    margin-left: 8px;
+    padding: 2px 8px;
+    font-size: 0.8em;
+    border-radius: 10px;
+    background-color: #555;
+    color: #fff;
+  }
+</style>

--- a/src/JsonValidator/ZarrConventions/index.svelte
+++ b/src/JsonValidator/ZarrConventions/index.svelte
@@ -31,30 +31,72 @@ const unusedConventions = conventions.filter(
     Zarr Conventions found: {conventions.length}
     <ZarrConventionsTooltip></ZarrConventionsTooltip>
     </h3>
-    <div class="json">
-    <JsonBrowser
-    name=""
-    contents={{ "zarr_conventions": conventions }}
-    expanded={false}
-    />
-    </div>
 
-{#each conventions as convention}
+{#each conventions as convention, index}
+    <!--
+        Each Convention Metadata Object MUST contain at least one of the following fields:
+        uuid, schema_url, or spec_url.
+    -->
 
-        {#if convention.name}
-            <p>Convention name: <code>{convention.name}</code></p>
+<!-- The zarr_conventions attribute MUST be an array of Convention Metadata Objects (CMO).
+Each CMO:
+https://github.com/zarr-conventions/zarr-conventions-spec
+
+At least one of schema_url, spec_url, or uuid MUST be present.
+If uuid is present, it serves as the primary unique identifier for the Convention.
+If uuid is not present and both schema_url and spec_url are present, the schema_url serves as the identifier.
+If only spec_url is present (and no uuid), it serves as the identifier.
+If the Convention uses versioning, the schema_url
+SHOULD include a reference to the specific version (e.g., v1)
+and the spec_url MAY include a reference to the specific version.
+The Convention SHOULD provide a convenient way to find the specification associated with each version.
+
+Additionally, a Convention Metadata Object SHOULD contain the following fields:
+
+    name - a short human-readable name
+    schema_url and spec_url - when using uuid as the primary identifier, they are RECOMMENDED
+ -->
+
+ <!-- Each Convention Metadata Object MUST contain at least one of the following fields: -->
+
+          {#if convention.name}
+            <h4>Convention {index + 1}: <code>{convention.name}</code></h4 >
+          {:else}
+            <h4>Convention {index + 1}</h4>
+          {/if}
+         {#if !(convention.uuid || convention.schema_url || convention.spec_url)}
+            <p class="warning">
+                Convention must have at least one of uuid, schema_url, or spec_url
+            </p>
+        {:else}
+            <p>
+                {#if convention.uuid}
+                    UUID: <code>{convention.uuid}</code>
+                {/if}
+                {#if convention.schema_url}
+                    <a href={convention.schema_url} target="_blank">Schema URL</a>
+                {/if}
+                {#if convention.spec_url}
+                    <a href={convention.spec_url} target="_blank">Spec URL</a>
+                {/if}
+            </p>
+        {/if}
+
+    <!-- Spec says:
+
+         If the Convention isolates metadata using a namespace prefix or a key for nesting,
+         the name SHOULD match the namespace prefix (e.g., proj:)
+         or the key used to nest attributes (e.g., ome), depending on which method is used.
+        -->
+
+          {#if convention.name}
+            <!-- TODO: check for namespace prefixes (e.g. ome:)-->
             {#if !(convention.name in zarrAttrs)}
                 <p class="warning">
-                  <code>{convention.name}</code> not found in root attributes
+                  <code>{convention.name}</code> not found in the attributes
                 </p>
-                <p>Attributes:
-                    <div class="json">
-    <JsonBrowser
-    name=""
-    contents={attrKeys}
-    expanded
-    />
-    </div>
+                <p>Found: <code>{attrKeys.filter((k) => k !== "zarr_conventions")}</code></p>
+
             {/if}
         {:else}
             <p>(No name provided for convention)</p>

--- a/src/JsonValidator/ZarrConventions/index.svelte
+++ b/src/JsonValidator/ZarrConventions/index.svelte
@@ -1,81 +1,105 @@
-<script>
-  import DetailsPrePanel from "../../JsonBrowser/DetailsPrePanel.svelte";
-  import ZarrConventionsTooltip from "./ZarrConventionsTooltip.svelte";
+    <script>
+    import ZarrConventionsTooltip from "./ZarrConventionsTooltip.svelte";
+    import JsonBrowser from "../../JsonBrowser/index.svelte";
 
-  export let source;
-  export let rootAttrs;
+    export let source;
+    export let rootAttrs;
 
-  const zarrAttrs = rootAttrs?.attributes || rootAttrs;
-  const conventions = zarrAttrs?.zarr_conventions || [];
-  // Per spec README, only the underscore key "metadata_assets" is valid.
-  const assets = zarrAttrs?.metadata_assets || [];
+    const zarrAttrs = rootAttrs?.attributes || rootAttrs;
 
-  const isAbsolute = (href) => /^https?:\/\//i.test(href) || href?.startsWith("/");
-  const assetUrl = (href) => (isAbsolute(href) ? href : `${source}/${href}`);
-</script>
+    const conventions = zarrAttrs?.zarr_conventions || [];
+    const assets = zarrAttrs?.metadata_assets || [];
 
-<div class="zarr-conventions">
-  {#if conventions.length > 0}
-    <h2>
-      Zarr Conventions found: {conventions.length}
-      <ZarrConventionsTooltip></ZarrConventionsTooltip>
-    </h2>
-    <DetailsPrePanel jsonData={conventions} summary="zarr_conventions" />
+    const isAbsolute = (href) => /^https?:\/\//i.test(href) || href?.startsWith("/");
+    const assetUrl = (href) => (isAbsolute(href) ? href : `${source}/${href}`);
 
-    {#if assets.length > 0}
-      <h3>Metadata assets</h3>
-      <ul>
-        {#each assets as asset}
-          <li>
-            <a href={assetUrl(asset.href)} target="_blank">{asset.href}</a>
-            {#if asset.kind}<span class="badge">{asset.kind}</span>{/if}
-            {#if asset.media_type}<span class="badge">{asset.media_type}</span>{/if}
-            {#if asset.attributes}
-              <DetailsPrePanel jsonData={asset.attributes} summary="attributes" />
-            {/if}
-          </li>
-        {/each}
-      </ul>
+    const kindMap = {
+        "ro-crate": "https://www.researchobject.org/ro-crate/",
+        "croissant": "https://docs.mlcommons.org/croissant/",
+        "ome-xml": "https://ome-model.readthedocs.io/en/stable/ome-xml/",
+        "czi-xml": "https://www.zeiss.com/microscopy/en/products/software/zeiss-zen/czi-image-file-format.html",
+        "datapackage": "https://datapackage.org/",
+    }
+    </script>
+
+    <div class="zarr-conventions">
+    {#if conventions.length > 0}
+        <h3>
+        Zarr Conventions found: {conventions.length}
+        <ZarrConventionsTooltip></ZarrConventionsTooltip>
+        </h3>
+        <div class="json">
+        <JsonBrowser
+        name=""
+        contents={{ "zarr_conventions": conventions }}
+        expanded={false}
+        />
+        </div>
+        {#if assets.length > 0}
+        <h3>Metadata assets</h3>
+        <div class="metadata-assets">
+        <ul>
+            {#each assets as asset}
+            <li>
+                <a href={assetUrl(asset.href)} target="_blank">{asset.href}</a>
+                {#if asset.kind}
+                    {#if kindMap[asset.kind]}
+                        <span class="badge"><a href={kindMap[asset.kind]} target="_blank">{asset.kind}</a></span>
+                    {:else}
+                        <span class="badge">{asset.kind}</span>
+                    {/if}
+                {/if}
+                </li>
+            {/each}
+        </ul>
+        </div>
+        {/if}
+    {:else}
+        <p>No Zarr Conventions found <ZarrConventionsTooltip></ZarrConventionsTooltip></p>
     {/if}
-  {:else}
-    <p>No Zarr Conventions found <ZarrConventionsTooltip></ZarrConventionsTooltip></p>
-  {/if}
-</div>
+    </div>
 
-<style>
-  .zarr-conventions {
-    border-radius: 10px;
-    padding: 15px 0;
-    margin: 15px 0;
-    box-shadow: 5px 5px 10px #c3c0c0;
-    background: linear-gradient(to right, #ccc, #aaa);
-    text-align: center;
-  }
+    <style>
 
-  .zarr-conventions ul {
-    list-style: none;
-    padding: 0;
-    margin: 10px 0;
-    text-align: left;
-    display: inline-block;
-  }
+    .metadata-assets ul {
+        list-style: none;
+        margin: 10px 0;
+        text-align: left;
+        display: inline-block;
+    }
 
-  .zarr-conventions li {
-    margin: 6px 0;
-  }
+    .json {
+        text-align: left;
+        margin-top: 10px;
+        margin: 15px;
+        margin-bottom: 20px;
+        color: #faebd7;
+        background-color: #263749;
+        padding: 20px;
+        font-size: 14px;
+        border-radius: 10px;
+        font-family: monospace;
+    }
 
-  .zarr-conventions a,
-  .zarr-conventions a:visited {
-    color: var(--omeLinkBlue);
-  }
 
-  .badge {
-    display: inline-block;
-    margin-left: 8px;
-    padding: 2px 8px;
-    font-size: 0.8em;
-    border-radius: 10px;
-    background-color: #555;
-    color: #fff;
-  }
-</style>
+    .zarr-conventions {
+        border-radius: 10px;
+        padding: 15px 0;
+        margin: 15px 0;
+        margin-top: 30px;
+        margin-bottom: 30px;
+        box-shadow: 5px 5px 10px #c3c0c0;
+        background: linear-gradient(to right, #ccc, #aaa);
+        text-align: center;
+    }
+
+    .badge {
+        display: inline-block;
+        margin-left: 8px;
+        padding: 2px 8px;
+        font-size: 0.8em;
+        border-radius: 10px;
+        background-color: #6e6c6c60;
+        color: rgb(27, 27, 27)000;
+    }
+    </style>

--- a/src/JsonValidator/index.svelte
+++ b/src/JsonValidator/index.svelte
@@ -2,6 +2,7 @@
   import MultiscaleArrays from "./MultiscaleArrays/index.svelte";
   import Plate from "./Plate/index.svelte";
   import RoCrate from "./RoCrate/index.svelte";
+  import ZarrConventions from "./ZarrConventions/index.svelte";
   import Well from "./Well/index.svelte";
   import JsonBrowser from "../JsonBrowser/index.svelte";
   import CheckMark from "../CheckMark.svelte";
@@ -106,6 +107,8 @@
       expanded
     />
   </div>
+
+  <ZarrConventions {source} {rootAttrs} />
 
   <!-- for v0.5+ we check for ro-crate-metadata.json -->
   {#if !["0.1", "0.2", "0.3", "0.4"].includes(version)}

--- a/src/JsonValidator/index.svelte
+++ b/src/JsonValidator/index.svelte
@@ -74,7 +74,7 @@
     Validating: <a href={source}/{zarrAttrsFileName}>/{zarrName}/{zarrAttrsFileName}</a>
   </p>
   {versionMessage}
-  Using schema{schemaUrls.length > 1 ? "s" : ""}: 
+  Using schema{schemaUrls.length > 1 ? "s" : ""}:
   {#each schemaUrls as url, i}
     {i > 0 ? " and " : ""}
     <a href={url} target="_blank">{url.split("ngff")[1]}</a>
@@ -107,8 +107,11 @@
       expanded
     />
   </div>
+  <!-- for v0.5+ we also check for Zarr Conventions -->
+  {#if !["0.1", "0.2", "0.3", "0.4"].includes(version)}
+    <ZarrConventions {source} {rootAttrs} />
+  {/if}
 
-  <ZarrConventions {source} {rootAttrs} />
 
   <!-- for v0.5+ we check for ro-crate-metadata.json -->
   {#if !["0.1", "0.2", "0.3", "0.4"].includes(version)}

--- a/src/utils.js
+++ b/src/utils.js
@@ -325,3 +325,45 @@ export function getSearchParam(key) {
 export function range(length) {
   return Array.from({ length }, (_, i) => i);
 }
+
+/**
+ * Select the best thumbnail from the thumbnails convention.
+ * Prefers largest edge up to maxEdge (512), preferring JPEG over PNG.
+ * @param {Array} thumbnails - Array of thumbnail objects with width, height, media_type, path/url
+ * @param {number} maxEdge - Maximum edge size (default 512)
+ * @returns {Object|null} - Best thumbnail object or null
+ */
+export function selectBestThumbnail(thumbnails, maxEdge = 512) {
+  if (!thumbnails || !Array.isArray(thumbnails) || thumbnails.length === 0) {
+    return null;
+  }
+  
+  // Filter to thumbnails with largest edge <= maxEdge
+  const candidates = thumbnails.filter(t => 
+    Math.max(t.width, t.height) <= maxEdge
+  );
+  
+  // If none fit, fall back to smallest available
+  const pool = candidates.length > 0 ? candidates : thumbnails;
+  
+  // Sort by: largest edge descending, then prefer JPEG over PNG
+  return pool.sort((a, b) => {
+    const aEdge = Math.max(a.width, a.height);
+    const bEdge = Math.max(b.width, b.height);
+    
+    // If we have candidates (fit under maxEdge), prefer larger
+    // If using fallback (all too big), prefer smaller
+    if (candidates.length > 0) {
+      if (bEdge !== aEdge) return bEdge - aEdge;
+    } else {
+      if (aEdge !== bEdge) return aEdge - bEdge;
+    }
+    
+    // Same size: prefer JPEG
+    const aJpeg = a.media_type === 'image/jpeg';
+    const bJpeg = b.media_type === 'image/jpeg';
+    if (aJpeg && !bJpeg) return -1;
+    if (!aJpeg && bJpeg) return 1;
+    return 0;
+  })[0];
+}


### PR DESCRIPTION
Testing support for https://github.com/clbarnes/zarr-convention-thumbnails 

Checks for thumbnail convention and uses thumbnail when available, fallback to ome-zarr.js when no thumbnails are present. 

The convention is WIP, opening the PR for the deploy preview