### PR TITLE
bump_ome-zarr.js@0.0.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "ajv": "^8.11.0",
         "ndarray": "^1.0.19",
-        "ome-zarr.js": "^0.0.14",
+        "ome-zarr.js": "^0.0.19",
         "svelte-icons-pack": "^1.4.6",
         "svelte-simple-modal": "^1.4.1",
         "zarrita": "^0.5.0"
@@ -601,9 +601,9 @@
       }
     },
     "node_modules/ome-zarr.js": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.14.tgz",
-      "integrity": "sha512-j7EMcZXJOUdqZI5LNj+rtTOhMBN/ac2TUGq/V5avawdTxGCGXjsZsZRR7YKq2YmdyQQit2tF1Vm1OnIDL22fjg==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.19.tgz",
+      "integrity": "sha512-z+pP9AlUMvkfHBQ24F9KsjRgIDq9taeC23///ZQA/gzWOjlgbkcJlraJhjljESQC9fYYs+FiWkPsp7TAcS77ag==",
       "license": "BSD",
       "dependencies": {
         "zarrita": "^0.5.0"
@@ -1180,9 +1180,9 @@
       }
     },
     "ome-zarr.js": {
-      "version": "0.0.14",
-      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.14.tgz",
-      "integrity": "sha512-j7EMcZXJOUdqZI5LNj+rtTOhMBN/ac2TUGq/V5avawdTxGCGXjsZsZRR7YKq2YmdyQQit2tF1Vm1OnIDL22fjg==",
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/ome-zarr.js/-/ome-zarr.js-0.0.19.tgz",
+      "integrity": "sha512-z+pP9AlUMvkfHBQ24F9KsjRgIDq9taeC23///ZQA/gzWOjlgbkcJlraJhjljESQC9fYYs+FiWkPsp7TAcS77ag==",
       "requires": {
         "zarrita": "^0.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "ajv": "^8.11.0",
     "ndarray": "^1.0.19",
-    "ome-zarr.js": "^0.0.14",
+    "ome-zarr.js": "^0.0.19",
     "svelte-icons-pack": "^1.4.6",
     "svelte-simple-modal": "^1.4.1",
     "zarrita": "^0.5.0"


### PR DESCRIPTION
Bump ome-zarr.js@0.0.19

Fixes e.g. https://deploy-preview-73--ome-ngff-validator.netlify.app/?source=https://s3.janelia.org/flyefish/EASI-FISH_NP_SS_OMEZarr/NP01_R1_20230906/NP01_R1_1_1_SS00790_AstA_546_CCHa1_647_100x_ROL.zarr
which doesn't work with older version.