### PR TITLE
Update vizarr href to the biongff fork

### DIFF
--- a/public/ngff_viewers.json
+++ b/public/ngff_viewers.json
@@ -3,7 +3,7 @@
     {
       "name": "vizarr",
       "logo": "/vizarr_logo.png",
-      "href": "https://hms-dbmi.github.io/vizarr/?source="
+      "href": "https://biongff.github.io/vizarr/?source="
     },
     {
       "name": "itk-vtk-viewer",


### PR DESCRIPTION
The biongff fork (https://github.com/BioNGFF/vizarr) has support for displaying labels and fixes a few bugs. 

@will-moore do you think it is mature enough for changing the link here?  