### PR TITLE
schemas url parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,12 @@ Web page for validating OME-NGFF files
 Deployed at https://ome.github.io/ome-ngff-validator
 
 See https://idr.github.io/ome-ngff-samples/ for samples to try.
+
+## Custom schemas
+
+To specify a location to load schemas from, use the `schemas` query parameter.
+For example, this will load schemas from a specified branch of the ngff-spec repo:
+
+```
+&schemas=https://raw.githubusercontent.com/will-moore/ngff-spec/refs/heads/scene_coordinateTransformations_input_path_optional/schemas/
+```

--- a/src/utils.js
+++ b/src/utils.js
@@ -291,13 +291,13 @@ export async function validate(jsonData) {
 
   if (version.startsWith("0.6")) {
     refSchemas = [];
-    // Since the image.schema has $id: https://ngff.openmicroscopy.org/0.6.dev4/schemas/image.schema
+    // Since the image.schema has $id: https://ngff.openmicroscopy.org/0.6rc0/schemas/image.schema
     // and contains "$ref": "coordinate_systems.schema" etc
     // We need to use the same URL prefix for all those $ref schemas
     const names = ["coordinate_transformations", "coordinate_systems", "axes", "_version"];
     for(const name of names) {
       const schema = await getSchema(getSchemaUrl(name, version));
-      schema["$id"] = `https://ngff.openmicroscopy.org/0.6.dev4/schemas/${name}.schema`;
+      schema["$id"] = `https://ngff.openmicroscopy.org/0.6rc0/schemas/${name}.schema`;
       refSchemas.push(schema);
     }
     jsonData = jsonData.attributes;

--- a/src/utils.js
+++ b/src/utils.js
@@ -9,7 +9,8 @@ export const FILE_NOT_FOUND = "File not found";
 export function getSchemaUrl(schemaName, version) {
   // check for query param override
   const schemas_url = getSearchParam("schemas");
-  let baseUrl = `https://ngff.openmicroscopy.org/${version}/schemas`;
+  // Use raw github URL since the link will also display in the browser
+  let baseUrl = `https://raw.githubusercontent.com/ome/ngff-spec/${version}/schemas`;
   if (schemas_url) {
     baseUrl = schemas_url;
   } else if (version.startsWith("0.6")) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -7,10 +7,18 @@ export const FILE_NOT_FOUND = "File not found";
 
 
 export function getSchemaUrl(schemaName, version) {
-  if (version.includes("0.6")) {
-    return `https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/schemas/${schemaName}.schema`;
+  // check for query param override
+  const schemas_url = getSearchParam("schemas");
+  let baseUrl = `https://ngff.openmicroscopy.org/${version}/schemas`;
+  if (schemas_url) {
+    baseUrl = schemas_url;
+  } else if (version.includes("0.6")) {
+    baseUrl = "https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/schemas";
   }
-  return `https://ngff.openmicroscopy.org/${version}/schemas/${schemaName}.schema`;
+  if (baseUrl.endsWith("/")) {
+    baseUrl = baseUrl.slice(0, -1);
+  }
+  return `${baseUrl}/${schemaName}.schema`;
 }
 
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ export function getSchemaUrl(schemaName, version) {
   let baseUrl = `https://ngff.openmicroscopy.org/${version}/schemas`;
   if (schemas_url) {
     baseUrl = schemas_url;
-  } else if (version.includes("0.6")) {
+  } else if (version.startsWith("0.6")) {
     baseUrl = "https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/schemas";
   }
   if (baseUrl.endsWith("/")) {


### PR DESCRIPTION
This PR makes a few changes, including some from #85.

 - Use raw github URLs for loading schemas. This means that when users follow the link provided to the schema, they see the schema in their browser (instead of forced download)
 - Updates the `$id` ref used for v0.6 schemas to `0.6rc0` since the dev schemas now use that version for all refs.
 - Adds support for `?schemas=url`, with the schemas being loaded from that URL, to allow testing with schemas at a particular location. All the various schemas, image, coordinate_transformations etc need to be present under that path. E.g. `&schemas=https://raw.githubusercontent.com/will-moore/ngff-spec/refs/heads/scene_coordinateTransformations_input_path_optional/schemas/` will load schemas from a specified branch of the `ngff-spec` repo.

To test:
 - See that currently for v0.6 data, validation fails because we can't resolve the `0.6rc0` refs. https://ome.github.io/ome-ngff-validator/?source=https://livingobjects.ebi.ac.uk/idr/zarr/test-data/v0.6.dev4/idr0050/4995115_output_to_ms.zarr/4995115_cropped_700_700_400_400_rot45.zarr 
 - This is fixed in this PR, allowing the validation to run: https://deploy-preview-80--ome-ngff-validator.netlify.app/?source=https://livingobjects.ebi.ac.uk/idr/zarr/test-data/v0.6.dev4/idr0050/4995115_output_to_ms.zarr/4995115_cropped_700_700_400_400_rot45.zarr (NB that particular `v0.6.dev4` sample fails validation because that is no-longer a valid version number for v06 schemas.
 - We can illustrate the use of custom schemas with a temp `ngff-spec` branch for testing this PR. In that branch, I have updated to allow `v0.6.dev4` as the version number. To test, see that using that *custom* schema with the same sample as above, we can get a "valid" result https://deploy-preview-80--ome-ngff-validator.netlify.app/?source=https://livingobjects.ebi.ac.uk/idr/zarr/test-data/v0.6.dev4/idr0050/4995115_output_to_ms.zarr/4995115_cropped_700_700_400_400_rot45.zarr&schemas=https://raw.githubusercontent.com/will-moore/ngff-spec/refs/heads/test_validator_schemas/schemas/
