### PR TITLE
feat: use red X icon for failing validation

### DIFF
--- a/src/JsonValidator/SceneGraph/MemberImagesList.svelte
+++ b/src/JsonValidator/SceneGraph/MemberImagesList.svelte
@@ -2,6 +2,7 @@
   import { getZarrGroupAttrs, validate } from "../../utils";
   import Icon from "svelte-icons-pack/Icon.svelte";
   import BsCheckCircleFill from "svelte-icons-pack/bs/BsCheckCircleFill";
+  import BsXCircleFill from "svelte-icons-pack/bs/BsXCircleFill";
 
   export let source;
   export let sceneAttrs;
@@ -72,14 +73,14 @@
               class:invalid={!isValid}
               title="Validate {path}"
             >
-              <Icon src={BsCheckCircleFill} />
+              <Icon src={isValid ? BsCheckCircleFill : BsXCircleFill} />
             </span>
           {:catch}
             <span 
               class="validate-icon invalid"
               title="Validate {path}"
             >
-              <Icon src={BsCheckCircleFill} />
+              <Icon src={BsXCircleFill} />
             </span>
           {/await}
         </div>


### PR DESCRIPTION
In the current version, a failing validation in the scene's `MemberImagesList` leads to this display:

<img width="444" height="137" alt="image" src="https://github.com/user-attachments/assets/649907e5-ef16-46f8-b978-e7beb8701d67" />

...which is very confusing. This PR uses a separate icon for a failing validation (`BsXCircleFill`), which should fix this.