### PR TITLE
feat: pull schema from ngff page's dev branch

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,7 @@ export const FILE_NOT_FOUND = "File not found";
 
 export function getSchemaUrl(schemaName, version) {
   if (version.includes("0.6")) {
-    return `https://raw.githubusercontent.com/ome/ngff-spec/refs/heads/main/schemas/${schemaName}.schema`;
+    return `https://ngff.openmicroscopy.org/dev/schemas/${schemaName}.schema`;
   }
   return `https://ngff.openmicroscopy.org/${version}/schemas/${schemaName}.schema`;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -288,7 +288,7 @@ export async function validate(jsonData) {
     const names = ["coordinate_transformations", "coordinate_systems", "axes", "_version"];
     for(const name of names) {
       const schema = await getSchema(getSchemaUrl(name, version));
-      schema["$id"] = `https://ngff.openmicroscopy.org/0.6.dev4/schemas/${name}.schema`;
+      schema["$id"] = `https://ngff.openmicroscopy.org/dev/schemas/${name}.schema`;
       refSchemas.push(schema);
     }
     jsonData = jsonData.attributes;


### PR DESCRIPTION
This PR changes the location from which to pull the schemas to the `dev` subpage of the ngff page, see also https://github.com/ome/ngff/issues/563. I'm not entirely sure why this previously worked with `0.6.dev4` hardcoded into the URL, though 🤔 